### PR TITLE
refactor: use readable names for logger methods

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -69,7 +69,7 @@ class _MyAppState extends State<MyApp> {
         SnackBar(content: Text("Joined ${result.$1.federationName}")),
       );
     } else {
-      AppLogger.instance.w('Scan result is null, not updating federations');
+      AppLogger.instance.warn('Scan result is null, not updating federations');
     }
   }
 

--- a/lib/fed_preview.dart
+++ b/lib/fed_preview.dart
@@ -41,12 +41,12 @@ class _FederationPreviewState extends State<FederationPreview> {
           inviteCode: widget.inviteCode,
           recover: false,
         );
-        AppLogger.instance.i('Successfully joined federation');
+        AppLogger.instance.info('Successfully joined federation');
         if (mounted) {
           Navigator.of(context).pop((fed, false));
         }
       } catch (e) {
-        AppLogger.instance.e('Could not join federation $e');
+        AppLogger.instance.error('Could not join federation $e');
         setState(() {
           isJoining = false;
         });
@@ -205,7 +205,9 @@ class _FederationPreviewState extends State<FederationPreview> {
                           Navigator.of(context).pop((fed, true));
                         }
                       } catch (e) {
-                        AppLogger.instance.e('Could not recover federation $e');
+                        AppLogger.instance.error(
+                          'Could not recover federation $e',
+                        );
                         setState(() {
                           isJoining = false;
                         });

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,7 +11,7 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await AppLogger.init();
   await RustLib.init();
-  AppLogger.instance.i("Starting Carbine...");
+  AppLogger.instance.info("Starting Carbine...");
   final dir = await getApplicationDocumentsDirectory();
   runApp(Carbine(dir: dir));
 }

--- a/lib/number_pad.dart
+++ b/lib/number_pad.dart
@@ -115,7 +115,7 @@ class _NumberPadState extends State<NumberPad> {
           child: EcashSend(fed: widget.fed, amountSats: amountSats),
         );
       } else if (widget.paymentType == PaymentType.onchain) {
-        AppLogger.instance.i('Generate bitcoin address and QR code');
+        AppLogger.instance.info('Generate bitcoin address and QR code');
       }
     }
     setState(() => _creating = false);

--- a/lib/payment_selector.dart
+++ b/lib/payment_selector.dart
@@ -125,7 +125,7 @@ class _PaymentMethodSelectorState extends State<PaymentMethodSelector> {
       try {
         final address = _lightningAddressController.text;
         final amount = BigInt.parse(_amountController.text) * BigInt.from(1000);
-        AppLogger.instance.i('Lightning Address: $address, Amount: $amount');
+        AppLogger.instance.info('Lightning Address: $address, Amount: $amount');
         await Navigator.push(
           context,
           MaterialPageRoute(
@@ -138,7 +138,7 @@ class _PaymentMethodSelectorState extends State<PaymentMethodSelector> {
           ),
         );
       } catch (e) {
-        AppLogger.instance.e("Error paying lightning address $e");
+        AppLogger.instance.error("Error paying lightning address $e");
       }
     } else {
       await Navigator.push(

--- a/lib/redeem_ecash.dart
+++ b/lib/redeem_ecash.dart
@@ -55,7 +55,7 @@ class _EcashRedeemPromptState extends State<EcashRedeemPrompt> {
       Navigator.of(context).popUntil((route) => route.isFirst);
     } catch (e) {
       // Could not reissue ecash
-      AppLogger.instance.e("Could not reissue ecash $e");
+      AppLogger.instance.error("Could not reissue ecash $e");
       Navigator.of(context).popUntil((route) => route.isFirst);
     }
   }

--- a/lib/scan.dart
+++ b/lib/scan.dart
@@ -98,10 +98,10 @@ class _ScanQRPageState extends State<ScanQRPage> {
             heightFactor: 0.25,
           );
         } catch (_) {
-          AppLogger.instance.e('Could not parse text as ecash');
+          AppLogger.instance.error('Could not parse text as ecash');
         }
       } else {
-        AppLogger.instance.w("Scanned unknown Text");
+        AppLogger.instance.warn("Scanned unknown Text");
       }
     }
   }

--- a/lib/sidebar.dart
+++ b/lib/sidebar.dart
@@ -143,7 +143,7 @@ class _FederationListItemState extends State<FederationListItem> {
         guardians = meta.$1.guardians;
       });
     } catch (e) {
-      AppLogger.instance.e('Failed to load federation metadata: $e');
+      AppLogger.instance.error('Failed to load federation metadata: $e');
     }
   }
 
@@ -156,7 +156,7 @@ class _FederationListItemState extends State<FederationListItem> {
         isLoading = false;
       });
     } else {
-      AppLogger.instance.w(
+      AppLogger.instance.warn(
         "FederationListItemState: we are still recovering, not getting balance",
       );
     }

--- a/lib/splash.dart
+++ b/lib/splash.dart
@@ -24,7 +24,7 @@ class _SplashState extends State<Splash> {
   Future<void> _checkWalletStatus() async {
     final exists = await walletExists(path: widget.dir.path);
 
-    AppLogger.instance.i("Wallet exists: $exists");
+    AppLogger.instance.info("Wallet exists: $exists");
 
     if (!mounted) return;
     final Widget screen;

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -27,7 +27,7 @@ class AppLogger {
       await _logFile.create(recursive: true);
     }
 
-    instance.i("Logger initialized. Log file: ${_logFile.path}");
+    instance.info("Logger initialized. Log file: ${_logFile.path}");
   }
 
   void _log(String level, String message) {
@@ -45,10 +45,10 @@ class AppLogger {
     );
   }
 
-  void i(String message) => _log("INFO", message);
-  void w(String message) => _log("WARN", message);
-  void e(String message) => _log("ERROR", message);
-  void d(String message) => _log("DEBUG", message);
+  void info(String message) => _log("INFO", message);
+  void warn(String message) => _log("WARN", message);
+  void error(String message) => _log("ERROR", message);
+  void debug(String message) => _log("DEBUG", message);
 }
 
 int threshold(int totalPeers) {


### PR DESCRIPTION
I've noticed AI generated code prefers brevity over readability. Meh.