### PR TITLE
ui: use bitcoin symbol and change sidebar icon

### DIFF
--- a/lib/number_pad.dart
+++ b/lib/number_pad.dart
@@ -64,9 +64,9 @@ class _NumberPadState extends State<NumberPad> {
   }
 
   String _formatAmount(String value) {
-    if (value.isEmpty) return '0';
+    if (value.isEmpty) return '₿0';
     final number = int.tryParse(value) ?? 0;
-    final formatter = NumberFormat('#,###', 'en_US');
+    final formatter = NumberFormat('₿#,###', 'en_US');
     return formatter.format(number).replaceAll(',', ' ');
   }
 
@@ -213,14 +213,6 @@ class _NumberPadState extends State<NumberPad> {
                     style: const TextStyle(
                       fontSize: 48,
                       fontWeight: FontWeight.w700,
-                    ),
-                  ),
-                  TextSpan(
-                    text: ' sats',
-                    style: TextStyle(
-                      fontSize: 24,
-                      fontWeight: FontWeight.w400,
-                      color: Colors.white70,
                     ),
                   ),
                 ],

--- a/lib/sidebar.dart
+++ b/lib/sidebar.dart
@@ -256,7 +256,7 @@ class _FederationListItemState extends State<FederationListItem> {
                   ),
                 ),
                 IconButton(
-                  icon: const Icon(Icons.qr_code),
+                  icon: const Icon(Icons.groups_outlined),
                   color: Colors.greenAccent,
                   onPressed: () {
                     showCarbineModalBottomSheet(

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -57,19 +57,19 @@ int threshold(int totalPeers) {
 }
 
 String formatBalance(BigInt? msats, bool showMsats) {
-  if (msats == null) return showMsats ? '0 msats' : '0 sats';
+  if (msats == null) return showMsats ? '₿0.000' : '₿0';
 
   if (showMsats) {
-    final formatter = NumberFormat('#,##0', 'en_US');
-    var formatted = formatter.format(msats.toInt());
-    formatted = formatted.replaceAll(',', ' ');
-    return '$formatted msats';
+    final btcAmount =
+        msats.toDouble() / 1000; // convert to sats with msat precision
+    final formatter = NumberFormat('#,##0.000', 'en_US');
+    var formatted = formatter.format(btcAmount).replaceAll(',', ' ');
+    return '₿$formatted';
   } else {
     final sats = msats.toSats;
     final formatter = NumberFormat('#,##0', 'en_US');
-    var formatted = formatter.format(sats.toInt());
-    formatted = formatted.replaceAll(',', ' ');
-    return '$formatted sats';
+    var formatted = formatter.format(sats.toInt()).replaceAll(',', ' ');
+    return '₿$formatted';
   }
 }
 


### PR DESCRIPTION
More wallets that I have seen are using the bitcoin "b" symbol instead of sats. I think its a bit cleaner.

![image](https://github.com/user-attachments/assets/e5f99604-bec6-4312-9c69-085c5ac6e431)

This PR also changes the icon for the sidebar, since we are not displaying a qr code.