### PR TITLE
fix: handle onchain and backup invite code errors

### DIFF
--- a/lib/fed_preview.dart
+++ b/lib/fed_preview.dart
@@ -41,6 +41,7 @@ class _FederationPreviewState extends State<FederationPreview> {
       setState(() {
         isJoining = true;
       });
+
       try {
         final fed = await joinFederation(
           inviteCode: widget.inviteCode!,
@@ -51,9 +52,6 @@ class _FederationPreviewState extends State<FederationPreview> {
         if (mounted) {
           Navigator.of(context).pop((fed, false));
         }
-
-        // backup the federation's invite codes as a replaceable event to Nostr
-        backupInviteCodes();
       } catch (e) {
         AppLogger.instance.error('Could not join federation $e');
         ToastService().show(
@@ -62,9 +60,17 @@ class _FederationPreviewState extends State<FederationPreview> {
           onTap: () {},
           icon: Icon(Icons.error),
         );
+      } finally {
         setState(() {
           isJoining = false;
         });
+      }
+
+      try {
+        // backup the federation's invite codes as a replaceable event to Nostr
+        backupInviteCodes();
+      } catch (e) {
+        AppLogger.instance.error("Could not backup Nostr invite codes: $e");
       }
     }
   }

--- a/lib/frb_generated.dart
+++ b/lib/frb_generated.dart
@@ -66,7 +66,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.9.0';
 
   @override
-  int get rustContentHash => -1087282765;
+  int get rustContentHash => -1514455697;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -765,11 +765,6 @@ abstract class RustLibApi extends BaseApi {
   });
 
   Future<void> crateLoadMultimint({required String path});
-
-  Future<void> crateMonitorDepositAddress({
-    required FederationId federationId,
-    required String address,
-  });
 
   Future<(ParsedText, FederationSelector)> crateParseScannedTextForFederation({
     required String text,
@@ -6630,43 +6625,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "load_multimint", argNames: ["path"]);
 
   @override
-  Future<void> crateMonitorDepositAddress({
-    required FederationId federationId,
-    required String address,
-  }) {
-    return handler.executeNormal(
-      NormalTask(
-        callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationId(
-            federationId,
-            serializer,
-          );
-          sse_encode_String(address, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 148,
-            port: port_,
-          );
-        },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_unit,
-          decodeErrorData: sse_decode_AnyhowException,
-        ),
-        constMeta: kCrateMonitorDepositAddressConstMeta,
-        argValues: [federationId, address],
-        apiImpl: this,
-      ),
-    );
-  }
-
-  TaskConstMeta get kCrateMonitorDepositAddressConstMeta => const TaskConstMeta(
-    debugName: "monitor_deposit_address",
-    argNames: ["federationId", "address"],
-  );
-
-  @override
   Future<(ParsedText, FederationSelector)> crateParseScannedTextForFederation({
     required String text,
     required FederationSelector federation,
@@ -6683,7 +6641,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 149,
+            funcId: 148,
             port: port_,
           );
         },
@@ -6717,7 +6675,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 150,
+            funcId: 149,
             port: port_,
           );
         },
@@ -6753,7 +6711,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 151,
+            funcId: 150,
             port: port_,
           );
         },
@@ -6796,7 +6754,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 152,
+            funcId: 151,
             port: port_,
           );
         },
@@ -6846,7 +6804,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 153,
+            funcId: 152,
             port: port_,
           );
         },
@@ -6889,7 +6847,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 154,
+            funcId: 153,
             port: port_,
           );
         },
@@ -6938,7 +6896,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 155,
+            funcId: 154,
             port: port_,
           );
         },
@@ -6968,7 +6926,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 156,
+            funcId: 155,
             port: port_,
           );
         },
@@ -6999,7 +6957,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 157,
+            funcId: 156,
             port: port_,
           );
         },
@@ -7034,7 +6992,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 158,
+            funcId: 157,
             port: port_,
           );
         },
@@ -7077,7 +7035,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 159,
+            funcId: 158,
             port: port_,
           );
         },
@@ -7121,7 +7079,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 160,
+            funcId: 159,
             port: port_,
           );
         },
@@ -7161,7 +7119,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 161,
+            funcId: 160,
             port: port_,
           );
         },
@@ -7194,7 +7152,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 162,
+            funcId: 161,
             port: port_,
           );
         },
@@ -7231,7 +7189,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 163,
+            funcId: 162,
             port: port_,
           );
         },
@@ -7269,7 +7227,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 164,
+              funcId: 163,
               port: port_,
             );
           },
@@ -7303,7 +7261,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 165,
+              funcId: 164,
               port: port_,
             );
           },
@@ -7346,7 +7304,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 166,
+              funcId: 165,
               port: port_,
             );
           },
@@ -7390,7 +7348,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 167,
+            funcId: 166,
             port: port_,
           );
         },
@@ -7420,7 +7378,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 168,
+            funcId: 167,
             port: port_,
           );
         },
@@ -7455,7 +7413,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 169,
+            funcId: 168,
             port: port_,
           );
         },
@@ -7499,7 +7457,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 170,
+            funcId: 169,
             port: port_,
           );
         },
@@ -7529,7 +7487,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 171,
+            funcId: 170,
             port: port_,
           );
         },

--- a/lib/lib.dart
+++ b/lib/lib.dart
@@ -187,14 +187,6 @@ Stream<DepositEventKind> subscribeDeposits({
   required FederationId federationId,
 }) => RustLib.instance.api.crateSubscribeDeposits(federationId: federationId);
 
-Future<void> monitorDepositAddress({
-  required FederationId federationId,
-  required String address,
-}) => RustLib.instance.api.crateMonitorDepositAddress(
-  federationId: federationId,
-  address: address,
-);
-
 Future<String> allocateDepositAddress({required FederationId federationId}) =>
     RustLib.instance.api.crateAllocateDepositAddress(
       federationId: federationId,

--- a/lib/onchain_receive.dart
+++ b/lib/onchain_receive.dart
@@ -1,6 +1,7 @@
 import 'package:carbine/lib.dart';
 import 'package:carbine/multimint.dart';
 import 'package:carbine/toast.dart';
+import 'package:carbine/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -24,14 +25,25 @@ class _OnChainReceiveContentState extends State<OnChainReceiveContent> {
   }
 
   Future<void> _fetchAddress() async {
-    final address = await allocateDepositAddress(
-      federationId: widget.fed.federationId,
-    );
-    if (!mounted) return;
-    setState(() {
-      _address = address;
-      _isLoading = false;
-    });
+    try {
+      final address = await allocateDepositAddress(
+        federationId: widget.fed.federationId,
+      );
+      if (!mounted) return;
+      setState(() {
+        _address = address;
+        _isLoading = false;
+      });
+    } catch (e) {
+      AppLogger.instance.error("Could not allocate deposit address: $e");
+      ToastService().show(
+        message: "Could not get new address",
+        duration: const Duration(seconds: 5),
+        onTap: () {},
+        icon: Icon(Icons.error),
+      );
+      Navigator.of(context).pop();
+    }
   }
 
   void _copyToClipboard(String text) {

--- a/rust/carbine_fedimint/src/frb_generated.rs
+++ b/rust/carbine_fedimint/src/frb_generated.rs
@@ -42,7 +42,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.9.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1087282765;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1514455697;
 
 // Section: executor
 
@@ -8167,44 +8167,6 @@ fn wire__crate__load_multimint_impl(
         },
     )
 }
-fn wire__crate__monitor_deposit_address_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "monitor_deposit_address",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_federation_id = <FederationId>::sse_decode(&mut deserializer);
-            let api_address = <String>::sse_decode(&mut deserializer);
-            deserializer.end();
-            move |context| async move {
-                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
-                    (move || async move {
-                        let output_ok =
-                            crate::monitor_deposit_address(api_federation_id, api_address).await?;
-                        Ok(output_ok)
-                    })()
-                    .await,
-                )
-            }
-        },
-    )
-}
 fn wire__crate__parse_scanned_text_for_federation_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -11120,32 +11082,31 @@ fn pde_ffi_dispatcher_primary_impl(
         145 => wire__crate__list_gateways_impl(port, ptr, rust_vec_len, data_len),
         146 => wire__crate__list_ln_address_domains_impl(port, ptr, rust_vec_len, data_len),
         147 => wire__crate__load_multimint_impl(port, ptr, rust_vec_len, data_len),
-        148 => wire__crate__monitor_deposit_address_impl(port, ptr, rust_vec_len, data_len),
-        149 => {
+        148 => {
             wire__crate__parse_scanned_text_for_federation_impl(port, ptr, rust_vec_len, data_len)
         }
-        150 => wire__crate__parsed_scanned_text_impl(port, ptr, rust_vec_len, data_len),
-        151 => wire__crate__payment_preview_impl(port, ptr, rust_vec_len, data_len),
-        152 => wire__crate__receive_impl(port, ptr, rust_vec_len, data_len),
-        153 => wire__crate__recheck_address_impl(port, ptr, rust_vec_len, data_len),
-        154 => wire__crate__register_ln_address_impl(port, ptr, rust_vec_len, data_len),
-        155 => wire__crate__reissue_ecash_impl(port, ptr, rust_vec_len, data_len),
-        156 => wire__crate__rejoin_from_backup_invites_impl(port, ptr, rust_vec_len, data_len),
-        157 => wire__crate__remove_relay_impl(port, ptr, rust_vec_len, data_len),
-        158 => wire__crate__select_receive_gateway_impl(port, ptr, rust_vec_len, data_len),
-        159 => wire__crate__send_impl(port, ptr, rust_vec_len, data_len),
-        160 => wire__crate__send_ecash_impl(port, ptr, rust_vec_len, data_len),
-        161 => wire__crate__send_lnaddress_impl(port, ptr, rust_vec_len, data_len),
-        162 => wire__crate__set_display_setting_impl(port, ptr, rust_vec_len, data_len),
-        163 => wire__crate__set_nwc_connection_info_impl(port, ptr, rust_vec_len, data_len),
-        164 => wire__crate__subscribe_deposits_impl(port, ptr, rust_vec_len, data_len),
-        165 => wire__crate__subscribe_multimint_events_impl(port, ptr, rust_vec_len, data_len),
-        166 => wire__crate__subscribe_recovery_progress_impl(port, ptr, rust_vec_len, data_len),
-        167 => wire__crate__transactions_impl(port, ptr, rust_vec_len, data_len),
-        168 => wire__crate__wallet_exists_impl(port, ptr, rust_vec_len, data_len),
-        169 => wire__crate__wallet_summary_impl(port, ptr, rust_vec_len, data_len),
-        170 => wire__crate__withdraw_to_address_impl(port, ptr, rust_vec_len, data_len),
-        171 => wire__crate__word_list_impl(port, ptr, rust_vec_len, data_len),
+        149 => wire__crate__parsed_scanned_text_impl(port, ptr, rust_vec_len, data_len),
+        150 => wire__crate__payment_preview_impl(port, ptr, rust_vec_len, data_len),
+        151 => wire__crate__receive_impl(port, ptr, rust_vec_len, data_len),
+        152 => wire__crate__recheck_address_impl(port, ptr, rust_vec_len, data_len),
+        153 => wire__crate__register_ln_address_impl(port, ptr, rust_vec_len, data_len),
+        154 => wire__crate__reissue_ecash_impl(port, ptr, rust_vec_len, data_len),
+        155 => wire__crate__rejoin_from_backup_invites_impl(port, ptr, rust_vec_len, data_len),
+        156 => wire__crate__remove_relay_impl(port, ptr, rust_vec_len, data_len),
+        157 => wire__crate__select_receive_gateway_impl(port, ptr, rust_vec_len, data_len),
+        158 => wire__crate__send_impl(port, ptr, rust_vec_len, data_len),
+        159 => wire__crate__send_ecash_impl(port, ptr, rust_vec_len, data_len),
+        160 => wire__crate__send_lnaddress_impl(port, ptr, rust_vec_len, data_len),
+        161 => wire__crate__set_display_setting_impl(port, ptr, rust_vec_len, data_len),
+        162 => wire__crate__set_nwc_connection_info_impl(port, ptr, rust_vec_len, data_len),
+        163 => wire__crate__subscribe_deposits_impl(port, ptr, rust_vec_len, data_len),
+        164 => wire__crate__subscribe_multimint_events_impl(port, ptr, rust_vec_len, data_len),
+        165 => wire__crate__subscribe_recovery_progress_impl(port, ptr, rust_vec_len, data_len),
+        166 => wire__crate__transactions_impl(port, ptr, rust_vec_len, data_len),
+        167 => wire__crate__wallet_exists_impl(port, ptr, rust_vec_len, data_len),
+        168 => wire__crate__wallet_summary_impl(port, ptr, rust_vec_len, data_len),
+        169 => wire__crate__withdraw_to_address_impl(port, ptr, rust_vec_len, data_len),
+        170 => wire__crate__word_list_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }

--- a/rust/carbine_fedimint/src/lib.rs
+++ b/rust/carbine_fedimint/src/lib.rs
@@ -477,17 +477,6 @@ pub async fn subscribe_deposits(sink: StreamSink<DepositEventKind>, federation_i
 }
 
 #[frb]
-pub async fn monitor_deposit_address(
-    federation_id: FederationId,
-    address: String,
-) -> anyhow::Result<()> {
-    let multimint = get_multimint();
-    multimint
-        .monitor_deposit_address(federation_id, address)
-        .await
-}
-
-#[frb]
 pub async fn allocate_deposit_address(federation_id: FederationId) -> anyhow::Result<String> {
     let multimint = get_multimint();
     multimint.allocate_deposit_address(federation_id).await


### PR DESCRIPTION
Working towards https://github.com/fedimint/fedimint-app/issues/43

 - Removes `monitor_deposit_address` - this is only called on the rust side
 - Wraps `backupInviteCodes` in its own try/catch
 - Wraps `allocateDepositAddress` in a try/catch