### PR TITLE
fix: UI updating every second during recovery

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -100,11 +100,13 @@ class _MyAppState extends State<MyApp> {
             icon: Icon(Icons.info),
           );
         } else {
-          _startOrResetRecoveryTimer();
-          setState(() {
-            _recoveryStatus =
-                "Trying to re-join ${event.field0} using peer ${event.field1}...";
-          });
+          if (_selectedFederation == null) {
+            _startOrResetRecoveryTimer();
+            setState(() {
+              _recoveryStatus =
+                  "Trying to re-join ${event.field0} using peer ${event.field1}...";
+            });
+          }
         }
       }
     });
@@ -213,6 +215,7 @@ class _MyAppState extends State<MyApp> {
       _isRecovering = recovering;
       _currentIndex = 0;
     });
+    _recoveryTimer?.cancel();
   }
 
   Future<void> _refreshFederations() async {


### PR DESCRIPTION
https://github.com/fedimint/e-cash-app/pull/146 introduced a bug where the recovery UI would update every second causing the screen to flash and look weird. The fix is to cancel the timer any time the `_selectedFederation` is set.