### PR TITLE
fix: add timeout when getting federation preview

### DIFF
--- a/lib/discover.dart
+++ b/lib/discover.dart
@@ -66,6 +66,9 @@ class _Discover extends State<Discover> {
         onTap: () {},
         icon: Icon(Icons.error),
       );
+      setState(() {
+        _gettingMetadata = null;
+      });
     }
   }
 


### PR DESCRIPTION
I noticed that when a federation is offline and we try to join it, if it can't get the preview it will try forever. This PR adds a timeout after 1 min so that it eventually stops trying.