### PR TITLE
chore: conditionally set package id for prod

### DIFF
--- a/.github/actions/android-build/action.yml
+++ b/.github/actions/android-build/action.yml
@@ -4,6 +4,10 @@ inputs:
   mode:
     description: "Build mode: debug or release"
     required: true
+  use-production-package-id:
+    description: "Use production package ID (org.fedimint.app) instead of development (org.fedimint.app.master)"
+    required: false
+    default: "false"
   with-signing:
     description: "Whether to set up Android signing"
     required: false
@@ -103,6 +107,21 @@ runs:
     - name: Install Flutter dependencies
       shell: bash
       run: flutter pub get
+
+    - name: Update package ID for production release
+      if: inputs.use-production-package-id == 'true'
+      shell: bash
+      run: |
+        # Update namespace and applicationId in build.gradle.kts
+        sed -i 's/namespace = ".*"/namespace = "org.fedimint.app"/' android/app/build.gradle.kts
+        sed -i 's/applicationId = ".*"/applicationId = "org.fedimint.app"/' android/app/build.gradle.kts
+
+        # Update package in MainActivity.kt
+        CURRENT_PACKAGE=$(grep '^package ' android/app/src/main/kotlin/app/ecash/MainActivity.kt | sed 's/package //')
+        sed -i "s/package ${CURRENT_PACKAGE}/package org.fedimint.app/" android/app/src/main/kotlin/app/ecash/MainActivity.kt
+
+        # Update APPLICATION_ID in Linux CMakeLists.txt
+        sed -i 's/set(APPLICATION_ID ".*")/set(APPLICATION_ID "org.fedimint.app")/' linux/CMakeLists.txt
 
     - name: Build Rust library for Android
       shell: bash

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: ./.github/actions/android-build
         with:
           mode: release
+          use-production-package-id: ${{ startsWith(github.ref, 'refs/tags/') }}
           with-signing: true
           android-keystore: ${{ secrets.ANDROID_KEYSTORE }}
           keystore-password: ${{ secrets.KEYSTORE_PASSWORD }}


### PR DESCRIPTION
For tagged releases we'll use `org.fedimint.app`, everything else uses `org.fedimint.app.master`. This ensures the dev builds are a separate app on android.