### PR TITLE
fix: rm non-ARM architectures in gradle build

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -34,6 +34,10 @@ android {
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
+
+        ndk {
+            abiFilters.add("arm64-v8a")
+        }
     }
 
     signingConfigs {


### PR DESCRIPTION
Followup to https://github.com/fedimint/e-cash-app/issues/201

Verified locally

```
stachurski@e-cash-app-builder:~/code/e-cash-app/apk-builds$ ls -al
total 207200
drwxrwxr-x  2 stachurski stachurski      4096 Sep  9 15:41 .
drwxrwxr-x 14 stachurski stachurski      4096 Sep  9 15:41 ..
-rw-rw-r--  1 stachurski stachurski 133465168 Sep  9 15:40 e-cash-debug-dev-20250909_154057.apk
-rw-rw-r--  1 stachurski stachurski  78692102 Sep  9 15:41 e-cash-debug-dev-20250909_154146.apk
stachurski@e-cash-app-builder:~/code/e-cash-app/apk-builds$
echo "=== APK SIZE COMPARISON ==="
=== APK SIZE COMPARISON ===
echo "BEFORE fix: $(ls -lh e-cash-debug-dev-20250909_154057.apk | awk '{print $5}')"
BEFORE fix: 128M
echo "AFTER fix:  $(ls -lh e-cash-debug-dev-20250909_154146.apk | awk '{print $5}')"
AFTER fix:  76M
echo "Reduction:  $(( ($(stat -c%s e-cash-debug-dev-20250909_154057.apk) - $(stat -c%s e-cash-debug-dev-20250909_154146.apk)) / 1024 / 1024 )) MB"
Reduction:  52 MB
echo ""

echo "=== ARCHITECTURES INCLUDED ==="
=== ARCHITECTURES INCLUDED ===
echo "BEFORE fix:"
BEFORE fix:
unzip -l e-cash-debug-dev-20250909_154057.apk | grep "lib/" | cut -d/ -f2 | sort -u | sed 's/^/  /'
  arm64-v8a
  armeabi-v7a
  x86
  x86_64
echo "AFTER fix:"
AFTER fix:
unzip -l e-cash-debug-dev-20250909_154146.apk | grep "lib/" | cut -d/ -f2 | sort -u | sed 's/^/  /'
  arm64-v8a
echo ""

echo "=== LIBRARY SIZES ==="
=== LIBRARY SIZES ===
echo "BEFORE fix:"
BEFORE fix:
unzip -lv e-cash-debug-dev-20250909_154057.apk | grep "lib/" | awk '{comp+=$3; uncomp+=$1} END {printf "  Total: %.1f MB compressed (%.1f MB uncompressed)\n", comp/1024/1024, uncomp/1024/1024}'
  Total: 100.1 MB compressed (244.2 MB uncompressed)
unzip -lv e-cash-debug-dev-20250909_154057.apk | grep "lib/" | grep -v "arm64-v8a" | awk '{comp+=$3; uncomp+=$1} END {printf "  Non-ARM64: %.1f MB compressed (%.1f MB uncompressed)\n", comp/1024/1024, uncomp/1024/1024}'
  Non-ARM64: 52.2 MB compressed (126.7 MB uncompressed)
echo "AFTER fix:"
AFTER fix:
unzip -lv e-cash-debug-dev-20250909_154146.apk | grep "lib/" | awk '{comp+=$3; uncomp+=$1} END {printf "  Total: %.1f MB compressed (%.1f MB uncompressed)\n", comp/1024/1024, uncomp/1024/1024}'
  Total: 47.9 MB compressed (117.4 MB uncompressed)
echo ""

echo "=== MISSING libecashapp.so ON OTHER ARCHS (BEFORE) ==="
=== MISSING libecashapp.so ON OTHER ARCHS (BEFORE) ===
unzip -l e-cash-debug-dev-20250909_154057.apk | grep libecashapp.so || echo "  Only found in ARM64"
 58618176  1981-01-01 01:01   lib/arm64-v8a/libecashapp.so
```