### PR TITLE
chore: optimize lib size

### DIFF
--- a/rust/ecashapp/Cargo.toml
+++ b/rust/ecashapp/Cargo.toml
@@ -45,3 +45,16 @@ tikv-jemalloc-sys = { opt-level = 3 }
 librocksdb-sys = { opt-level = 3 }
 secp256k1 = { opt-level = 3}
 secp256k1-sys = { opt-level = 3}
+
+[profile.release]
+opt-level = "z"
+lto = true
+codegen-units = 1
+strip = false
+debug = "line-tables-only"
+
+[profile.release.package]
+tikv-jemalloc-sys = { opt-level = 3 }
+librocksdb-sys = { opt-level = 3 }
+secp256k1 = { opt-level = 3}
+secp256k1-sys = { opt-level = 3}


### PR DESCRIPTION
Let's see if we can shrink our lib size. It seems odd that Fedi has a only 4MB larger FFI library than us even though it ships a whole matrix client in addition.

```
-rw-r--r-- 1 user users  60M Sep 11 19:06 libfediffi.so

-rw-r--r-- 1 user users   56M Sep 11 19:04 libecashapp.so
```