### PR TITLE
[backport v0.1]: fix: rm non-ARM architectures in gradle build

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -34,6 +34,10 @@ android {
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
+
+        ndk {
+            abiFilters.add("arm64-v8a")
+        }
     }
 
     signingConfigs {


### PR DESCRIPTION
Backport of https://github.com/fedimint/e-cash-app/pull/205