### PR TITLE
fix: unify message for failed claim

### DIFF
--- a/lib/redeem_ecash.dart
+++ b/lib/redeem_ecash.dart
@@ -29,6 +29,8 @@ class _EcashRedeemPromptState extends State<EcashRedeemPrompt> {
       _isLoading = true;
     });
 
+    final failureMessage = "Could not claim E-Cash";
+
     try {
       final isSpent = await checkEcashSpent(
         federationId: widget.fed.federationId,
@@ -64,7 +66,7 @@ class _EcashRedeemPromptState extends State<EcashRedeemPrompt> {
       if (result.$2 == null || result.$2 == BigInt.zero) {
         if (mounted) {
           ToastService().show(
-            message: "Redeem operation failed",
+            message: failureMessage,
             duration: const Duration(seconds: 5),
             onTap: () {},
             icon: Icon(Icons.error),
@@ -98,7 +100,7 @@ class _EcashRedeemPromptState extends State<EcashRedeemPrompt> {
       AppLogger.instance.error("Could not reissue E-Cash $e");
       if (mounted) {
         ToastService().show(
-          message: "Could not claim E-Cash",
+          message: failureMessage,
           duration: const Duration(seconds: 5),
           onTap: () {},
           icon: Icon(Icons.error),


### PR DESCRIPTION
Followup to https://github.com/fedimint/e-cash-app/pull/212#discussion_r2338285479

> nit: maybe we use the same error message as below: "Could not claim E-Cash"

Probably not worth backporting and making another RC unless we find other bugs worth of an RC.