### PR TITLE
chore: abbreviate long detail rows

### DIFF
--- a/lib/widgets/transaction_details.dart
+++ b/lib/widgets/transaction_details.dart
@@ -150,7 +150,14 @@ class _TransactionDetailsState extends State<TransactionDetails> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children:
                 widget.details.entries.map((entry) {
-                  final abbreviate = entry.key == TransactionDetailKeys.ecash;
+                  final abbreviate = const {
+                    TransactionDetailKeys.ecash,
+                    TransactionDetailKeys.txid,
+                    TransactionDetailKeys.address,
+                    TransactionDetailKeys.payeePublicKey,
+                    TransactionDetailKeys.paymentHash,
+                    TransactionDetailKeys.preimage,
+                  }.contains(entry.key);
 
                   if (entry.key == TransactionDetailKeys.txid) {
                     String? txid;


### PR DESCRIPTION
Some of the longer values in our transaction details make the screen a bit crowded. This updates these rows to show the abbreviated value.

Before (just one screen for brevity)
<img width="864" height="1920" alt="Screenshot_20250911-193045" src="https://github.com/user-attachments/assets/a227ab9a-47ee-4db7-8af4-0b1615ee5f61" />

After (all updated screens)

<img width="864" height="1920" alt="Screenshot_20250911-201727" src="https://github.com/user-attachments/assets/60cc842f-97f6-404d-9557-4a2601c0a19f" />
<img width="864" height="1920" alt="Screenshot_20250911-201339" src="https://github.com/user-attachments/assets/b1108153-e7ef-4bc1-9c1a-2e9957a18255" />
<img width="864" height="1920" alt="Screenshot_20250911-201144" src="https://github.com/user-attachments/assets/efc7b5fd-067d-42e1-80c5-6762e0bcc563" />
<img width="864" height="1920" alt="Screenshot_20250911-201136" src="https://github.com/user-attachments/assets/699c1605-a338-46d8-af81-13ab88012208" />
