### PR TITLE
feat: show LN address in transaction details when available

### DIFF
--- a/lib/constants/transaction_keys.dart
+++ b/lib/constants/transaction_keys.dart
@@ -14,6 +14,7 @@ class TransactionDetailKeys {
   static const String payeePublicKey = 'Payee Pubkey';
   static const String paymentHash = 'Payment Hash';
   static const String preimage = 'Preimage';
+  static const String lnAddress = 'LN Address';
   static const String minFeeRate = 'Min Fee Rate';
   static const String maxTxSize = 'Max Tx Size';
   static const String fee = 'Fee';

--- a/lib/frb_generated.dart
+++ b/lib/frb_generated.dart
@@ -486,6 +486,7 @@ abstract class RustLibApi extends BaseApi {
     required SafeUrl gateway,
     required bool isLnv2,
     required BigInt amountWithFees,
+    String? lnAddress,
   });
 
   Future<(OperationId, String, BigInt)> crateMultimintMultimintSendEcash({
@@ -862,6 +863,7 @@ abstract class RustLibApi extends BaseApi {
     required String gateway,
     required bool isLnv2,
     required BigInt amountWithFees,
+    String? lnAddress,
   });
 
   Future<(OperationId, String, BigInt)> crateSendEcash({
@@ -4224,6 +4226,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required SafeUrl gateway,
     required bool isLnv2,
     required BigInt amountWithFees,
+    String? lnAddress,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -4244,6 +4247,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           );
           sse_encode_bool(isLnv2, serializer);
           sse_encode_u_64(amountWithFees, serializer);
+          sse_encode_opt_String(lnAddress, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -4264,6 +4268,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           gateway,
           isLnv2,
           amountWithFees,
+          lnAddress,
         ],
         apiImpl: this,
       ),
@@ -4280,6 +4285,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           "gateway",
           "isLnv2",
           "amountWithFees",
+          "lnAddress",
         ],
       );
 
@@ -7396,6 +7402,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required String gateway,
     required bool isLnv2,
     required BigInt amountWithFees,
+    String? lnAddress,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -7409,6 +7416,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(gateway, serializer);
           sse_encode_bool(isLnv2, serializer);
           sse_encode_u_64(amountWithFees, serializer);
+          sse_encode_opt_String(lnAddress, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -7422,7 +7430,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeErrorData: sse_decode_AnyhowException,
         ),
         constMeta: kCrateSendConstMeta,
-        argValues: [federationId, invoice, gateway, isLnv2, amountWithFees],
+        argValues: [
+          federationId,
+          invoice,
+          gateway,
+          isLnv2,
+          amountWithFees,
+          lnAddress,
+        ],
         apiImpl: this,
       ),
     );
@@ -7436,6 +7451,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       "gateway",
       "isLnv2",
       "amountWithFees",
+      "lnAddress",
     ],
   );
 
@@ -9589,6 +9605,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           gateway: dco_decode_String(raw[2]),
           paymentHash: dco_decode_String(raw[3]),
           preimage: dco_decode_String(raw[4]),
+          lnAddress: dco_decode_opt_String(raw[5]),
         );
       case 2:
         return TransactionKind_LightningRecurring();
@@ -11494,11 +11511,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         var var_gateway = sse_decode_String(deserializer);
         var var_paymentHash = sse_decode_String(deserializer);
         var var_preimage = sse_decode_String(deserializer);
+        var var_lnAddress = sse_decode_opt_String(deserializer);
         return TransactionKind_LightningSend(
           fees: var_fees,
           gateway: var_gateway,
           paymentHash: var_paymentHash,
           preimage: var_preimage,
+          lnAddress: var_lnAddress,
         );
       case 2:
         return TransactionKind_LightningRecurring();
@@ -13465,12 +13484,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         gateway: final gateway,
         paymentHash: final paymentHash,
         preimage: final preimage,
+        lnAddress: final lnAddress,
       ):
         sse_encode_i_32(1, serializer);
         sse_encode_u_64(fees, serializer);
         sse_encode_String(gateway, serializer);
         sse_encode_String(paymentHash, serializer);
         sse_encode_String(preimage, serializer);
+        sse_encode_opt_String(lnAddress, serializer);
       case TransactionKind_LightningRecurring():
         sse_encode_i_32(2, serializer);
       case TransactionKind_OnchainReceive(
@@ -14384,6 +14405,7 @@ class MultimintImpl extends RustOpaque implements Multimint {
     required SafeUrl gateway,
     required bool isLnv2,
     required BigInt amountWithFees,
+    String? lnAddress,
   }) => RustLib.instance.api.crateMultimintMultimintSend(
     that: this,
     federationId: federationId,
@@ -14391,6 +14413,7 @@ class MultimintImpl extends RustOpaque implements Multimint {
     gateway: gateway,
     isLnv2: isLnv2,
     amountWithFees: amountWithFees,
+    lnAddress: lnAddress,
   );
 
   Future<(OperationId, String, BigInt)> sendEcash({

--- a/lib/lib.dart
+++ b/lib/lib.dart
@@ -103,12 +103,14 @@ Future<OperationId> send({
   required String gateway,
   required bool isLnv2,
   required BigInt amountWithFees,
+  String? lnAddress,
 }) => RustLib.instance.api.crateSend(
   federationId: federationId,
   invoice: invoice,
   gateway: gateway,
   isLnv2: isLnv2,
   amountWithFees: amountWithFees,
+  lnAddress: lnAddress,
 );
 
 Future<LightningSendOutcome> awaitSend({

--- a/lib/multimint.dart
+++ b/lib/multimint.dart
@@ -246,6 +246,7 @@ abstract class Multimint implements RustOpaqueInterface {
     required SafeUrl gateway,
     required bool isLnv2,
     required BigInt amountWithFees,
+    String? lnAddress,
   });
 
   Future<(OperationId, String, BigInt)> sendEcash({
@@ -646,6 +647,7 @@ sealed class TransactionKind with _$TransactionKind {
     required String gateway,
     required String paymentHash,
     required String preimage,
+    String? lnAddress,
   }) = TransactionKind_LightningSend;
   const factory TransactionKind.lightningRecurring() =
       TransactionKind_LightningRecurring;

--- a/lib/multimint.freezed.dart
+++ b/lib/multimint.freezed.dart
@@ -1562,13 +1562,14 @@ as String,
 
 
 class TransactionKind_LightningSend extends TransactionKind {
-  const TransactionKind_LightningSend({required this.fees, required this.gateway, required this.paymentHash, required this.preimage}): super._();
+  const TransactionKind_LightningSend({required this.fees, required this.gateway, required this.paymentHash, required this.preimage, this.lnAddress}): super._();
   
 
  final  BigInt fees;
  final  String gateway;
  final  String paymentHash;
  final  String preimage;
+ final  String? lnAddress;
 
 /// Create a copy of TransactionKind
 /// with the given fields replaced by the non-null parameter values.
@@ -1580,16 +1581,16 @@ $TransactionKind_LightningSendCopyWith<TransactionKind_LightningSend> get copyWi
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is TransactionKind_LightningSend&&(identical(other.fees, fees) || other.fees == fees)&&(identical(other.gateway, gateway) || other.gateway == gateway)&&(identical(other.paymentHash, paymentHash) || other.paymentHash == paymentHash)&&(identical(other.preimage, preimage) || other.preimage == preimage));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is TransactionKind_LightningSend&&(identical(other.fees, fees) || other.fees == fees)&&(identical(other.gateway, gateway) || other.gateway == gateway)&&(identical(other.paymentHash, paymentHash) || other.paymentHash == paymentHash)&&(identical(other.preimage, preimage) || other.preimage == preimage)&&(identical(other.lnAddress, lnAddress) || other.lnAddress == lnAddress));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,fees,gateway,paymentHash,preimage);
+int get hashCode => Object.hash(runtimeType,fees,gateway,paymentHash,preimage,lnAddress);
 
 @override
 String toString() {
-  return 'TransactionKind.lightningSend(fees: $fees, gateway: $gateway, paymentHash: $paymentHash, preimage: $preimage)';
+  return 'TransactionKind.lightningSend(fees: $fees, gateway: $gateway, paymentHash: $paymentHash, preimage: $preimage, lnAddress: $lnAddress)';
 }
 
 
@@ -1600,7 +1601,7 @@ abstract mixin class $TransactionKind_LightningSendCopyWith<$Res> implements $Tr
   factory $TransactionKind_LightningSendCopyWith(TransactionKind_LightningSend value, $Res Function(TransactionKind_LightningSend) _then) = _$TransactionKind_LightningSendCopyWithImpl;
 @useResult
 $Res call({
- BigInt fees, String gateway, String paymentHash, String preimage
+ BigInt fees, String gateway, String paymentHash, String preimage, String? lnAddress
 });
 
 
@@ -1617,13 +1618,14 @@ class _$TransactionKind_LightningSendCopyWithImpl<$Res>
 
 /// Create a copy of TransactionKind
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? fees = null,Object? gateway = null,Object? paymentHash = null,Object? preimage = null,}) {
+@pragma('vm:prefer-inline') $Res call({Object? fees = null,Object? gateway = null,Object? paymentHash = null,Object? preimage = null,Object? lnAddress = freezed,}) {
   return _then(TransactionKind_LightningSend(
 fees: null == fees ? _self.fees : fees // ignore: cast_nullable_to_non_nullable
 as BigInt,gateway: null == gateway ? _self.gateway : gateway // ignore: cast_nullable_to_non_nullable
 as String,paymentHash: null == paymentHash ? _self.paymentHash : paymentHash // ignore: cast_nullable_to_non_nullable
 as String,preimage: null == preimage ? _self.preimage : preimage // ignore: cast_nullable_to_non_nullable
-as String,
+as String,lnAddress: freezed == lnAddress ? _self.lnAddress : lnAddress // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 

--- a/lib/widgets/transaction_item.dart
+++ b/lib/widgets/transaction_item.dart
@@ -48,12 +48,14 @@ class TransactionItem extends StatelessWidget {
         gateway: final gateway,
         paymentHash: final paymentHash,
         preimage: final preimage,
+        lnAddress: final lnAddress,
       ):
         showAppModalBottomSheet(
           context: context,
           child: TransactionDetails(
             tx: tx,
             details: {
+              if (lnAddress != null) TransactionDetailKeys.lnAddress: lnAddress,
               TransactionDetailKeys.amount: formattedAmount,
               TransactionDetailKeys.fees: formatBalance(fees, true),
               TransactionDetailKeys.gateway: gateway,

--- a/rust/ecashapp/src/frb_generated.rs
+++ b/rust/ecashapp/src/frb_generated.rs
@@ -4809,6 +4809,7 @@ fn wire__crate__multimint__Multimint_send_impl(
             let api_gateway = <SafeUrl>::sse_decode(&mut deserializer);
             let api_is_lnv2 = <bool>::sse_decode(&mut deserializer);
             let api_amount_with_fees = <u64>::sse_decode(&mut deserializer);
+            let api_ln_address = <Option<String>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| async move {
                 transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
@@ -4850,6 +4851,7 @@ fn wire__crate__multimint__Multimint_send_impl(
                             api_gateway,
                             api_is_lnv2,
                             api_amount_with_fees,
+                            api_ln_address,
                         )
                         .await?;
                         Ok(output_ok)
@@ -9218,6 +9220,7 @@ fn wire__crate__send_impl(
             let api_gateway = <String>::sse_decode(&mut deserializer);
             let api_is_lnv2 = <bool>::sse_decode(&mut deserializer);
             let api_amount_with_fees = <u64>::sse_decode(&mut deserializer);
+            let api_ln_address = <Option<String>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| async move {
                 transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
@@ -9247,6 +9250,7 @@ fn wire__crate__send_impl(
                             api_gateway,
                             api_is_lnv2,
                             api_amount_with_fees,
+                            api_ln_address,
                         )
                         .await?;
                         Ok(output_ok)
@@ -11206,11 +11210,13 @@ impl SseDecode for crate::multimint::TransactionKind {
                 let mut var_gateway = <String>::sse_decode(deserializer);
                 let mut var_paymentHash = <String>::sse_decode(deserializer);
                 let mut var_preimage = <String>::sse_decode(deserializer);
+                let mut var_lnAddress = <Option<String>>::sse_decode(deserializer);
                 return crate::multimint::TransactionKind::LightningSend {
                     fees: var_fees,
                     gateway: var_gateway,
                     payment_hash: var_paymentHash,
                     preimage: var_preimage,
+                    ln_address: var_lnAddress,
                 };
             }
             2 => {
@@ -12835,12 +12841,14 @@ impl flutter_rust_bridge::IntoDart for crate::multimint::TransactionKind {
                 gateway,
                 payment_hash,
                 preimage,
+                ln_address,
             } => [
                 1.into_dart(),
                 fees.into_into_dart().into_dart(),
                 gateway.into_into_dart().into_dart(),
                 payment_hash.into_into_dart().into_dart(),
                 preimage.into_into_dart().into_dart(),
+                ln_address.into_into_dart().into_dart(),
             ]
             .into_dart(),
             crate::multimint::TransactionKind::LightningRecurring => [2.into_dart()].into_dart(),
@@ -14111,12 +14119,14 @@ impl SseEncode for crate::multimint::TransactionKind {
                 gateway,
                 payment_hash,
                 preimage,
+                ln_address,
             } => {
                 <i32>::sse_encode(1, serializer);
                 <u64>::sse_encode(fees, serializer);
                 <String>::sse_encode(gateway, serializer);
                 <String>::sse_encode(payment_hash, serializer);
                 <String>::sse_encode(preimage, serializer);
+                <Option<String>>::sse_encode(ln_address, serializer);
             }
             crate::multimint::TransactionKind::LightningRecurring => {
                 <i32>::sse_encode(2, serializer);

--- a/rust/ecashapp/src/lib.rs
+++ b/rust/ecashapp/src/lib.rs
@@ -321,6 +321,7 @@ pub async fn send_lnaddress(
                     gateway,
                     is_lnv2,
                     amount_with_fees,
+                    Some(address),
                 )
                 .await;
         }
@@ -335,11 +336,19 @@ pub async fn send(
     gateway: String,
     is_lnv2: bool,
     amount_with_fees: u64,
+    ln_address: Option<String>,
 ) -> anyhow::Result<OperationId> {
     let multimint = get_multimint();
     let gateway = SafeUrl::parse(&gateway)?;
     multimint
-        .send(federation_id, invoice, gateway, is_lnv2, amount_with_fees)
+        .send(
+            federation_id,
+            invoice,
+            gateway,
+            is_lnv2,
+            amount_with_fees,
+            ln_address,
+        )
         .await
 }
 

--- a/rust/ecashapp/src/nostr.rs
+++ b/rust/ecashapp/src/nostr.rs
@@ -458,6 +458,7 @@ impl NostrClient {
                     payment_preview.gateway,
                     payment_preview.is_lnv2,
                     payment_preview.amount_with_fees,
+                    None,
                 )
                 .await?;
                 let final_state = await_send(federation_id, operation_id).await;


### PR DESCRIPTION
Not a blocker for `v0.1.0`, but it'd be a nice touch to show the LN Address in the Lightning Send details.

Send with LN Address
<img width="864" height="1920" alt="Screenshot_20250911-212704" src="https://github.com/user-attachments/assets/cda87149-9360-4ba6-b78b-ebab85ca34e1" />

Send without LN Address
<img width="864" height="1920" alt="Screenshot_20250911-212655" src="https://github.com/user-attachments/assets/038754e2-c84b-456b-9220-f89c069862b2" />

