### PR TITLE
[Backport] fix: downgrade package_info_plus to support old kotlin

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   crypto: ^3.0.6
   collection: ^1.19.1
   shimmer: ^3.0.0
-  package_info_plus: ^9.0.0
+  package_info_plus: 8.3.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Backport https://github.com/fedimint/e-cash-app/pull/232