### PR TITLE
chore: bump version to v0.1.1-alpha

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ecashapp
 description: "A Fedimint Wallet"
 publish_to: 'none'
-version: 0.1.0-rc.5
+version: 0.1.1-alpha
 
 environment:
   sdk: ^3.7.2

--- a/rust/ecashapp/Cargo.lock
+++ b/rust/ecashapp/Cargo.lock
@@ -1283,7 +1283,7 @@ checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "ecashapp"
-version = "0.1.0-rc.5"
+version = "0.1.1-alpha"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/rust/ecashapp/Cargo.toml
+++ b/rust/ecashapp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecashapp"
-version = "0.1.0-rc.5"
+version = "0.1.1-alpha"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
We cut `v0.1.0` so we should bump the release branch version