### PR TITLE
refactor: bottom modal sheet takes async function

### DIFF
--- a/lib/discover.dart
+++ b/lib/discover.dart
@@ -49,7 +49,6 @@ class _Discover extends State<Discover> with SingleTickerProviderStateMixin {
 
   Future<void> _onPreviewPressed(String inviteCode) async {
     try {
-      final meta = await getFederationMeta(inviteCode: inviteCode);
       setState(() {
         _gettingMetadata = null;
         _isLoadingInvitePreview = false;
@@ -57,14 +56,17 @@ class _Discover extends State<Discover> with SingleTickerProviderStateMixin {
 
       final fed = await showAppModalBottomSheet(
         context: context,
-        child: FederationPreview(
-          fed: meta.selector,
-          inviteCode: inviteCode,
-          welcomeMessage: meta.welcome,
-          imageUrl: meta.picture,
-          joinable: true,
-          guardians: meta.guardians,
-        ),
+        childBuilder: () async {
+          final meta = await getFederationMeta(inviteCode: inviteCode);
+          return FederationPreview(
+            fed: meta.selector,
+            inviteCode: inviteCode,
+            welcomeMessage: meta.welcome,
+            imageUrl: meta.picture,
+            joinable: true,
+            guardians: meta.guardians,
+          );
+        },
       );
 
       if (fed != null) {

--- a/lib/fed_preview.dart
+++ b/lib/fed_preview.dart
@@ -671,8 +671,7 @@ class _FederationPreviewState extends State<FederationPreview> {
                                                       () =>
                                                           Navigator.of(
                                                             context,
-                                                            rootNavigator:
-                                                                true,
+                                                            rootNavigator: true,
                                                           ).pop(),
                                                   child: Container(
                                                     width: double.infinity,

--- a/lib/scan.dart
+++ b/lib/scan.dart
@@ -149,17 +149,19 @@ class _ScanQRPageState extends State<ScanQRPage> {
         case ParsedText_InviteCode(:final field0):
           if (widget.paymentType == null) {
             try {
-              final meta = await getFederationMeta(inviteCode: field0);
               final fed = await showAppModalBottomSheet(
                 context: context,
-                child: FederationPreview(
-                  fed: meta.selector,
-                  inviteCode: field0,
-                  welcomeMessage: meta.welcome,
-                  imageUrl: meta.picture,
-                  joinable: true,
-                  guardians: meta.guardians,
-                ),
+                childBuilder: () async {
+                  final meta = await getFederationMeta(inviteCode: field0);
+                  return FederationPreview(
+                    fed: meta.selector,
+                    inviteCode: field0,
+                    welcomeMessage: meta.welcome,
+                    imageUrl: meta.picture,
+                    joinable: true,
+                    guardians: meta.guardians,
+                  );
+                },
               );
               if (fed != null) {
                 await Future.delayed(const Duration(milliseconds: 400));
@@ -182,19 +184,22 @@ class _ScanQRPageState extends State<ScanQRPage> {
           if (widget.paymentType == null ||
               widget.paymentType! == PaymentType.lightning) {
             try {
-              final preview = await paymentPreview(
-                federationId: chosenFederation!.federationId,
-                bolt11: field0,
-              );
               await showAppModalBottomSheet(
                 context: context,
-                child: PaymentPreviewWidget(
-                  fed: chosenFederation,
-                  paymentPreview: preview,
-                ),
+                childBuilder: () async {
+                  final preview = await paymentPreview(
+                    federationId: chosenFederation!.federationId,
+                    bolt11: field0,
+                  );
+
+                  return PaymentPreviewWidget(
+                    fed: chosenFederation,
+                    paymentPreview: preview,
+                  );
+                },
               );
 
-              widget.onPay(chosenFederation, false);
+              widget.onPay(chosenFederation!, false);
             } catch (e) {
               AppLogger.instance.warn(
                 "Error when retrieving payment preview: $e",
@@ -214,12 +219,14 @@ class _ScanQRPageState extends State<ScanQRPage> {
             if (field1 != null) {
               await showAppModalBottomSheet(
                 context: context,
-                child: OnchainSend(
-                  fed: chosenFederation!,
-                  amountSats: field1.toSats,
-                  withdrawalMode: WithdrawalMode.specificAmount,
-                  defaultAddress: field0,
-                ),
+                childBuilder: () async {
+                  return OnchainSend(
+                    fed: chosenFederation!,
+                    amountSats: field1.toSats,
+                    withdrawalMode: WithdrawalMode.specificAmount,
+                    defaultAddress: field0,
+                  );
+                },
               );
             } else {
               final btcPrice = await fetchBtcPrice();
@@ -246,15 +253,17 @@ class _ScanQRPageState extends State<ScanQRPage> {
             invoicePaidToastVisible.value = false;
             await showAppModalBottomSheet(
               context: context,
-              child: EcashRedeemPrompt(
-                fed: chosenFederation!,
-                ecash: text,
-                amount: field0,
-              ),
+              childBuilder: () async {
+                return EcashRedeemPrompt(
+                  fed: chosenFederation!,
+                  ecash: text,
+                  amount: field0,
+                );
+              },
               heightFactor: 0.33,
             );
             invoicePaidToastVisible.value = true;
-            widget.onPay(chosenFederation, false);
+            widget.onPay(chosenFederation!, false);
           }
           break;
         case ParsedText_LightningAddressOrLnurl(:final field0):

--- a/lib/screens/dashboard.dart
+++ b/lib/screens/dashboard.dart
@@ -169,7 +169,9 @@ class _DashboardState extends State<Dashboard> {
     if (_selectedPaymentType == PaymentType.lightning) {
       await showAppModalBottomSheet(
         context: context,
-        child: PaymentMethodSelector(fed: widget.fed),
+        childBuilder: () async {
+          return PaymentMethodSelector(fed: widget.fed);
+        },
       );
     } else if (_selectedPaymentType == PaymentType.ecash ||
         _selectedPaymentType == PaymentType.onchain) {
@@ -210,7 +212,9 @@ class _DashboardState extends State<Dashboard> {
     } else if (_selectedPaymentType == PaymentType.onchain) {
       await showAppModalBottomSheet(
         context: context,
-        child: OnChainReceiveContent(fed: widget.fed),
+        childBuilder: () async {
+          return OnChainReceiveContent(fed: widget.fed);
+        },
         heightFactor: 0.33,
       );
       _loadAddresses();

--- a/lib/setttings.dart
+++ b/lib/setttings.dart
@@ -136,10 +136,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
             subtitle: 'View your seed phrase',
             warning: hasAck == false,
             onTap: () async {
-              final words = await getMnemonic();
               await showAppModalBottomSheet(
                 context: context,
-                child: Mnemonic(words: words, hasAck: hasAck!),
+                childBuilder: () async {
+                  final words = await getMnemonic();
+                  return Mnemonic(words: words, hasAck: hasAck!);
+                },
               );
               _checkSeedAck();
             },

--- a/lib/sidebar.dart
+++ b/lib/sidebar.dart
@@ -268,14 +268,16 @@ class _FederationListItemState extends State<FederationListItem> {
                   onPressed: () {
                     showAppModalBottomSheet(
                       context: context,
-                      child: FederationPreview(
-                        fed: widget.fed,
-                        welcomeMessage: welcomeMessage,
-                        imageUrl: federationImageUrl,
-                        joinable: false,
-                        guardians: guardians,
-                        onLeaveFederation: widget.onLeaveFederation,
-                      ),
+                      childBuilder: () async {
+                        return FederationPreview(
+                          fed: widget.fed,
+                          welcomeMessage: welcomeMessage,
+                          imageUrl: federationImageUrl,
+                          joinable: false,
+                          guardians: guardians,
+                          onLeaveFederation: widget.onLeaveFederation,
+                        );
+                      },
                     );
                   },
                 ),

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -55,7 +55,7 @@ final ThemeData cypherpunkNinjaTheme = ThemeData(
 
 Future<T?> showAppModalBottomSheet<T>({
   required BuildContext context,
-  required Widget child,
+  required Future<Widget> Function() childBuilder,
   double? heightFactor,
 }) {
   return showModalBottomSheet<T>(
@@ -86,11 +86,35 @@ Future<T?> showAppModalBottomSheet<T>({
                     borderRadius: BorderRadius.circular(2),
                   ),
                 ),
-                // Scrollable content
+                // Async content
                 Expanded(
-                  child: SingleChildScrollView(
-                    padding: const EdgeInsets.symmetric(horizontal: 16),
-                    child: child,
+                  child: FutureBuilder<Widget>(
+                    future: childBuilder(),
+                    builder: (context, snapshot) {
+                      if (snapshot.connectionState == ConnectionState.waiting) {
+                        return const Center(
+                          child: Padding(
+                            padding: EdgeInsets.all(24.0),
+                            child: CircularProgressIndicator(),
+                          ),
+                        );
+                      } else if (snapshot.hasError) {
+                        return Center(
+                          child: Padding(
+                            padding: const EdgeInsets.all(24.0),
+                            child: Text(
+                              'Error loading content',
+                              style: TextStyle(color: Colors.red),
+                            ),
+                          ),
+                        );
+                      } else {
+                        return SingleChildScrollView(
+                          padding: const EdgeInsets.symmetric(horizontal: 16),
+                          child: snapshot.data!,
+                        );
+                      }
+                    },
                   ),
                 ),
               ],

--- a/lib/widgets/gateways.dart
+++ b/lib/widgets/gateways.dart
@@ -75,7 +75,9 @@ class GatewaysList extends StatelessWidget {
                 onTap: () {
                   showAppModalBottomSheet(
                     context: context,
-                    child: GatewayDetailsSheet(gateway: g),
+                    childBuilder: () async {
+                      return GatewayDetailsSheet(gateway: g);
+                    },
                   );
                 },
               ),

--- a/lib/widgets/transaction_details.dart
+++ b/lib/widgets/transaction_details.dart
@@ -108,7 +108,13 @@ class _TransactionDetailsState extends State<TransactionDetails> {
       invoicePaidToastVisible.value = false;
       await showAppModalBottomSheet(
         context: context,
-        child: EcashRedeemPrompt(fed: widget.fed, ecash: ecash, amount: amount),
+        childBuilder: () async {
+          return EcashRedeemPrompt(
+            fed: widget.fed,
+            ecash: ecash,
+            amount: amount,
+          );
+        },
         heightFactor: 0.33,
       );
       invoicePaidToastVisible.value = true;

--- a/lib/widgets/transaction_item.dart
+++ b/lib/widgets/transaction_item.dart
@@ -28,19 +28,21 @@ class TransactionItem extends StatelessWidget {
       ):
         showAppModalBottomSheet(
           context: context,
-          child: TransactionDetails(
-            tx: tx,
-            details: {
-              TransactionDetailKeys.amount: formattedAmount,
-              TransactionDetailKeys.fees: formatBalance(fees, true),
-              TransactionDetailKeys.gateway: gateway,
-              TransactionDetailKeys.payeePublicKey: payeePubkey,
-              TransactionDetailKeys.paymentHash: paymentHash,
-              TransactionDetailKeys.timestamp: formattedDate,
-            },
-            icon: icon,
-            fed: fed,
-          ),
+          childBuilder: () async {
+            return TransactionDetails(
+              tx: tx,
+              details: {
+                TransactionDetailKeys.amount: formattedAmount,
+                TransactionDetailKeys.fees: formatBalance(fees, true),
+                TransactionDetailKeys.gateway: gateway,
+                TransactionDetailKeys.payeePublicKey: payeePubkey,
+                TransactionDetailKeys.paymentHash: paymentHash,
+                TransactionDetailKeys.timestamp: formattedDate,
+              },
+              icon: icon,
+              fed: fed,
+            );
+          },
         );
         break;
       case TransactionKind_LightningSend(
@@ -52,20 +54,23 @@ class TransactionItem extends StatelessWidget {
       ):
         showAppModalBottomSheet(
           context: context,
-          child: TransactionDetails(
-            tx: tx,
-            details: {
-              if (lnAddress != null) TransactionDetailKeys.lnAddress: lnAddress,
-              TransactionDetailKeys.amount: formattedAmount,
-              TransactionDetailKeys.fees: formatBalance(fees, true),
-              TransactionDetailKeys.gateway: gateway,
-              TransactionDetailKeys.paymentHash: paymentHash,
-              TransactionDetailKeys.preimage: preimage,
-              TransactionDetailKeys.timestamp: formattedDate,
-            },
-            icon: icon,
-            fed: fed,
-          ),
+          childBuilder: () async {
+            return TransactionDetails(
+              tx: tx,
+              details: {
+                if (lnAddress != null)
+                  TransactionDetailKeys.lnAddress: lnAddress,
+                TransactionDetailKeys.amount: formattedAmount,
+                TransactionDetailKeys.fees: formatBalance(fees, true),
+                TransactionDetailKeys.gateway: gateway,
+                TransactionDetailKeys.paymentHash: paymentHash,
+                TransactionDetailKeys.preimage: preimage,
+                TransactionDetailKeys.timestamp: formattedDate,
+              },
+              icon: icon,
+              fed: fed,
+            );
+          },
         );
         break;
       case TransactionKind_EcashSend(
@@ -74,17 +79,19 @@ class TransactionItem extends StatelessWidget {
       ):
         showAppModalBottomSheet(
           context: context,
-          child: TransactionDetails(
-            tx: tx,
-            details: {
-              TransactionDetailKeys.amount: formattedAmount,
-              TransactionDetailKeys.fees: formatBalance(fees, true),
-              TransactionDetailKeys.ecash: oobNotes,
-              TransactionDetailKeys.timestamp: formattedDate,
-            },
-            icon: icon,
-            fed: fed,
-          ),
+          childBuilder: () async {
+            return TransactionDetails(
+              tx: tx,
+              details: {
+                TransactionDetailKeys.amount: formattedAmount,
+                TransactionDetailKeys.fees: formatBalance(fees, true),
+                TransactionDetailKeys.ecash: oobNotes,
+                TransactionDetailKeys.timestamp: formattedDate,
+              },
+              icon: icon,
+              fed: fed,
+            );
+          },
         );
         break;
       case TransactionKind_EcashReceive(
@@ -93,31 +100,35 @@ class TransactionItem extends StatelessWidget {
       ):
         showAppModalBottomSheet(
           context: context,
-          child: TransactionDetails(
-            tx: tx,
-            details: {
-              TransactionDetailKeys.amount: formattedAmount,
-              TransactionDetailKeys.fees: formatBalance(fees, true),
-              TransactionDetailKeys.ecash: oobNotes,
-              TransactionDetailKeys.timestamp: formattedDate,
-            },
-            icon: icon,
-            fed: fed,
-          ),
+          childBuilder: () async {
+            return TransactionDetails(
+              tx: tx,
+              details: {
+                TransactionDetailKeys.amount: formattedAmount,
+                TransactionDetailKeys.fees: formatBalance(fees, true),
+                TransactionDetailKeys.ecash: oobNotes,
+                TransactionDetailKeys.timestamp: formattedDate,
+              },
+              icon: icon,
+              fed: fed,
+            );
+          },
         );
         break;
       case TransactionKind_LightningRecurring():
         showAppModalBottomSheet(
           context: context,
-          child: TransactionDetails(
-            tx: tx,
-            details: {
-              TransactionDetailKeys.amount: formattedAmount,
-              TransactionDetailKeys.timestamp: formattedDate,
-            },
-            icon: icon,
-            fed: fed,
-          ),
+          childBuilder: () async {
+            return TransactionDetails(
+              tx: tx,
+              details: {
+                TransactionDetailKeys.amount: formattedAmount,
+                TransactionDetailKeys.timestamp: formattedDate,
+              },
+              icon: icon,
+              fed: fed,
+            );
+          },
         );
         break;
       case TransactionKind_OnchainReceive(
@@ -133,12 +144,14 @@ class TransactionItem extends StatelessWidget {
 
         showAppModalBottomSheet(
           context: context,
-          child: TransactionDetails(
-            tx: tx,
-            details: details,
-            icon: icon,
-            fed: fed,
-          ),
+          childBuilder: () async {
+            return TransactionDetails(
+              tx: tx,
+              details: details,
+              icon: icon,
+              fed: fed,
+            );
+          },
         );
         break;
       case TransactionKind_OnchainSend(
@@ -187,12 +200,14 @@ class TransactionItem extends StatelessWidget {
 
         showAppModalBottomSheet(
           context: context,
-          child: TransactionDetails(
-            tx: tx,
-            details: details,
-            icon: icon,
-            fed: fed,
-          ),
+          childBuilder: () async {
+            return TransactionDetails(
+              tx: tx,
+              details: details,
+              icon: icon,
+              fed: fed,
+            );
+          },
         );
         break;
     }


### PR DESCRIPTION
There are some spots in our code where "something happens" then we want to show a bottom modal sheet. Sometimes this happens when pressing a button or scanning a QR code. 

We ideally want the bottom modal sheet to be as responsive as possible, since it gives users an indication that something happened. In certain instances, we need to call an async function (i.e to get federation meta and display to user), and this sometimes takes time.

This refactor changes our bottom modal sheet to take an async function instead of just a child widget. So when the async function is executing, the bottom modal sheet is displayed with a spinner. When it is finished, the returned child widget is then shown to the user. 

Makes the app feel snappier.