### PR TITLE
fix: dont spawn subscription for operations with outcomes

### DIFF
--- a/lib/redeem_ecash.dart
+++ b/lib/redeem_ecash.dart
@@ -140,7 +140,7 @@ class _EcashRedeemPromptState extends State<EcashRedeemPrompt> {
 
       if (!mounted) return;
 
-      Navigator.of(context).pop();
+      Navigator.of(context).popUntil((route) => route.isFirst);
       ToastService().show(
         message: "E-Cash redeem started in background",
         duration: const Duration(seconds: 3),


### PR DESCRIPTION
Fixes: https://github.com/fedimint/ecash-app/issues/229

I'm having a hard time reproducing, but I believe we are seeing notifications on startup sometimes because we're spawning subscriptions for operations that already have an outcome. Fix is to check at startup if an outcome is present, and don't spawn the subscription if that's the case.

This also fixes a small bug when redeeming ecash offline where we are not returned to the dashboard.