### PR TITLE
fix: detect macOS for Android NDK paths in ARM build

### DIFF
--- a/scripts/build-arm-android.sh
+++ b/scripts/build-arm-android.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
 
+# Detect host OS for NDK path
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  NDK_HOST="darwin-x86_64"
+else
+  NDK_HOST="linux-x86_64"
+fi
+
 cd $ROOT/rust/ecashapp
-export CC_aarch64_linux_android=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang
-export CXX_aarch64_linux_android=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang++
+export CC_aarch64_linux_android=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/$NDK_HOST/bin/aarch64-linux-android21-clang
+export CXX_aarch64_linux_android=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/$NDK_HOST/bin/aarch64-linux-android21-clang++
 cargo ndk -t arm64-v8a -o $ROOT/android/app/src/main/jniLibs build --release --target aarch64-linux-android
-cp $ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so $ROOT/android/app/src/main/jniLibs/arm64-v8a/
+cp $ANDROID_NDK_HOME/toolchains/llvm/prebuilt/$NDK_HOST/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so $ROOT/android/app/src/main/jniLibs/arm64-v8a/


### PR DESCRIPTION
This is necessary for me to build on macOS.