### PR TITLE
feat: Push settings screen as page route

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -32,7 +32,6 @@ class _MyAppState extends State<MyApp> {
   int _refreshTrigger = 0;
   FederationSelector? _selectedFederation;
   bool? _isRecovering;
-  int _currentIndex = 0;
 
   late Stream<MultimintEvent> events;
   late StreamSubscription<MultimintEvent> _subscription;
@@ -176,7 +175,6 @@ class _MyAppState extends State<MyApp> {
     } else {
       _selectedFederation = null;
       _isRecovering = null;
-      _currentIndex = 0;
     }
   }
 
@@ -220,7 +218,6 @@ class _MyAppState extends State<MyApp> {
     setState(() {
       _selectedFederation = fed;
       _isRecovering = recovering;
-      _currentIndex = 0;
     });
     _recoveryTimer?.cancel();
   }
@@ -258,7 +255,6 @@ class _MyAppState extends State<MyApp> {
   void _onGettingStarted() {
     setState(() {
       _selectedFederation = null;
-      _currentIndex = 0;
     });
   }
 
@@ -273,41 +269,34 @@ class _MyAppState extends State<MyApp> {
         recovering: _isRecovering!,
       );
     } else {
-      if (_currentIndex == 1) {
-        bodyContent = SettingsScreen(
-          onJoin: _onJoinPressed,
-          onGettingStarted: _onGettingStarted,
-        );
-      } else {
-        if (recoverFederations) {
-          bodyContent = Center(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                const CircularProgressIndicator(),
-                const SizedBox(height: 16),
+      if (recoverFederations) {
+        bodyContent = Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const CircularProgressIndicator(),
+              const SizedBox(height: 16),
+              Text(
+                _recoveryStatus,
+                style: const TextStyle(fontSize: 16),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 16),
+              if (_recoverySecondsRemaining <= 15)
                 Text(
-                  _recoveryStatus,
-                  style: const TextStyle(fontSize: 16),
+                  "Peer might be offline, trying for $_recoverySecondsRemaining more seconds...",
+                  style: const TextStyle(
+                    fontSize: 16,
+                    color: Colors.red,
+                    fontWeight: FontWeight.w600,
+                  ),
                   textAlign: TextAlign.center,
                 ),
-                const SizedBox(height: 16),
-                if (_recoverySecondsRemaining <= 15)
-                  Text(
-                    "Peer might be offline, trying for $_recoverySecondsRemaining more seconds...",
-                    style: const TextStyle(
-                      fontSize: 16,
-                      color: Colors.red,
-                      fontWeight: FontWeight.w600,
-                    ),
-                    textAlign: TextAlign.center,
-                  ),
-              ],
-            ),
-          );
-        } else {
-          bodyContent = Discover(onJoin: _onJoinPressed);
-        }
+            ],
+          ),
+        );
+      } else {
+        bodyContent = Discover(onJoin: _onJoinPressed);
       }
     }
 
@@ -324,7 +313,10 @@ class _MyAppState extends State<MyApp> {
                   IconButton(
                     icon: const Icon(Icons.qr_code_scanner),
                     tooltip: 'Scan',
-                    constraints: const BoxConstraints(minWidth: 56, minHeight: 56),
+                    constraints: const BoxConstraints(
+                      minWidth: 56,
+                      minHeight: 56,
+                    ),
                     onPressed: () => _onScanPressed(innerContext),
                   ),
                 ],
@@ -336,10 +328,16 @@ class _MyAppState extends State<MyApp> {
                   onFederationSelected: _setSelectedFederation,
                   onLeaveFederation: _leaveFederation,
                   onSettingsPressed: () {
-                    setState(() {
-                      _currentIndex = 1;
-                      _selectedFederation = null;
-                    });
+                    Navigator.push(
+                      innerContext,
+                      MaterialPageRoute(
+                        builder:
+                            (context) => SettingsScreen(
+                              onJoin: _onJoinPressed,
+                              onGettingStarted: _onGettingStarted,
+                            ),
+                      ),
+                    );
                   },
                 ),
               ),

--- a/lib/discover.dart
+++ b/lib/discover.dart
@@ -11,7 +11,8 @@ import 'package:shimmer/shimmer.dart';
 
 class Discover extends StatefulWidget {
   final void Function(FederationSelector fed, bool recovering) onJoin;
-  const Discover({super.key, required this.onJoin});
+  final bool showAppBar;
+  const Discover({super.key, required this.onJoin, this.showAppBar = false});
 
   @override
   State<Discover> createState() => _Discover();
@@ -73,6 +74,13 @@ class _Discover extends State<Discover> with SingleTickerProviderStateMixin {
         final name = fed.$1.federationName;
         await Future.delayed(const Duration(milliseconds: 400));
         widget.onJoin(fed.$1, fed.$2);
+
+        // If we're in a pushed route (showAppBar is true), pop back to main screen
+        // so the user can see the newly joined federation
+        if (widget.showAppBar && mounted) {
+          Navigator.popUntil(context, (route) => route.isFirst);
+        }
+
         ToastService().show(
           message: "Joined $name",
           duration: const Duration(seconds: 5),
@@ -96,6 +104,7 @@ class _Discover extends State<Discover> with SingleTickerProviderStateMixin {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return Scaffold(
+      appBar: widget.showAppBar ? AppBar(title: const Text('Discover')) : null,
       backgroundColor: Colors.black,
       body: SafeArea(
         child: FutureBuilder<List<PublicFederation>>(

--- a/lib/setttings.dart
+++ b/lib/setttings.dart
@@ -1,4 +1,5 @@
 import 'package:ecashapp/db.dart';
+import 'package:ecashapp/discover.dart';
 import 'package:ecashapp/lib.dart';
 import 'package:ecashapp/ln_address.dart';
 import 'package:ecashapp/mnemonic.dart';
@@ -52,6 +53,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      appBar: AppBar(title: const Text('Settings')),
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
@@ -62,7 +64,18 @@ class _SettingsScreenState extends State<SettingsScreen> {
             ),
             title: "Discover",
             subtitle: "Find new or join existing federations",
-            onTap: widget.onGettingStarted,
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder:
+                      (context) => Discover(
+                        onJoin: widget.onJoin,
+                        showAppBar: true,
+                      ),
+                ),
+              );
+            },
           ),
           _SettingsOption(
             icon: Icon(


### PR DESCRIPTION
This pull request changes the settings screen so that it is an actual route that gets pushed on the navigator stack. I personally find a back arrow on the setting screen more intuitive and more design aligned with other apps. Screenshot:

<img width="911" height="641" alt="Setting_With_Back" src="https://github.com/user-attachments/assets/99c5fd2c-2c54-47fe-b130-003063eefcb9" />

With this change, I also needed to slightly change the "Discover" screen so that it is also push/popped from the stack when joining a federation via the settings. There is no change to joining your first federation. Gifs below show the Discover flow:

First federation:
![Discover_With_No_Init_Federation](https://github.com/user-attachments/assets/d0cd396c-6724-4add-9a70-decab6594afc)


Adding a federation via Settings:
![Discover_Under_Settings](https://github.com/user-attachments/assets/6f0c243a-6859-4dd3-82ee-f5c12cbd2af4)
