### PR TITLE
fix: check state before sending notification

### DIFF
--- a/rust/ecashapp/src/lib.rs
+++ b/rust/ecashapp/src/lib.rs
@@ -783,7 +783,10 @@ pub async fn parsed_scanned_text(
 
         // If none of our joined federation's can parse the ecash, lets prompt the user to join
         if let Some(invite_code) = notes.federation_invite() {
-            return Ok((ParsedText::InviteCodeWithEcash(invite_code.to_string(), text), None));
+            return Ok((
+                ParsedText::InviteCodeWithEcash(invite_code.to_string(), text),
+                None,
+            ));
         }
 
         return Ok((ParsedText::EcashNoFederation, None));


### PR DESCRIPTION
I noticed that we have a small bug when receiving lightning/ecash payments where we are not checking the final state before sending the notification to the front end. This manifests as false notifications for the user, which is confusing.

This PR adds the final state check.