### PR TITLE
feat: Show max send amount on number pad screen

### DIFF
--- a/lib/number_pad.dart
+++ b/lib/number_pad.dart
@@ -413,6 +413,9 @@ class _NumberPadState extends State<NumberPad> {
     final remainingBalance = _getRemainingBalance();
     final isOverBalance = _isAmountOverBalance();
     final theme = Theme.of(context);
+    final bitcoinDisplay = context.select<PreferencesProvider, BitcoinDisplay>(
+      (prefs) => prefs.bitcoinDisplay,
+    );
 
     return Center(
       child: AnimatedContainer(
@@ -516,7 +519,7 @@ class _NumberPadState extends State<NumberPad> {
                             color: isOverBalance ? Colors.red : Colors.grey,
                           ),
                           child: Text(
-                            formatBalance(remainingBalance, false),
+                            formatBalance(remainingBalance, false, bitcoinDisplay),
                           ),
                         ),
                 ],


### PR DESCRIPTION
Closes #263 

- Also added basic validation for empty values and values greater than max balance

Validation flow:
![numberpad_max](https://github.com/user-attachments/assets/4ddaafa6-6824-45b6-a878-7da18012d651)

Lightning request flow (hides the max text):

![lightning_request_max](https://github.com/user-attachments/assets/018bada7-61d4-4937-8073-ac9eb6190e57)
