### PR TITLE
fix: decode ecash as string

### DIFF
--- a/lib/scan.dart
+++ b/lib/scan.dart
@@ -174,7 +174,7 @@ class _ScanQRPageState extends State<ScanQRPage> {
 
       AppLogger.instance.info("Passed isValid check. Decoding payload...");
       AppLogger.instance.error("Payload: $payload");
-      final actualPayload = base64Encode(payload);
+      final actualPayload = utf8.decode(payload);
       AppLogger.instance.info("Decoded QR payload: $actualPayload");
       final parsed = await _handleText(actualPayload);
       if (!parsed) {


### PR DESCRIPTION
Fixes: https://github.com/fedimint/ecash-app/issues/293

I think I had a confusion or the AI did a bit too much when implementing https://github.com/fedimint/ecash-app/pull/250. We do not need to re-encode the ecash as base64, it is already being decoded from base64 earlier. We just need to interpret it as a utf8 string.