### PR TITLE
fix: Fix extra padding on federation list item

### DIFF
--- a/lib/sidebar.dart
+++ b/lib/sidebar.dart
@@ -49,9 +49,10 @@ class FederationSidebarState extends State<FederationSidebar> {
   void initState() {
     super.initState();
     // Initialize with loading state for each federation
-    _feds = widget.initialFederations
-        .map((fed) => (fed.$1, fed.$2, FederationPreviewData()))
-        .toList();
+    _feds =
+        widget.initialFederations
+            .map((fed) => (fed.$1, fed.$2, FederationPreviewData()))
+            .toList();
     _refreshFederations();
   }
 
@@ -138,53 +139,80 @@ class FederationSidebarState extends State<FederationSidebar> {
         child: Column(
           children: [
             Expanded(
-              child: _feds.isEmpty
-                  ? const Center(child: Text('No federations found'))
-                  : Column(
-                    children: [
-                      Container(
-                        height: 80,
-                        padding: const EdgeInsets.all(16),
-                        decoration: BoxDecoration(
-                          color: Colors.grey[900],
-                          border: Border(
-                            bottom: BorderSide(color: Colors.grey.shade800),
-                          ),
-                        ),
-                        alignment: Alignment.centerLeft,
-                        child: Text(
-                          'Federations',
-                          style: TextStyle(
-                            color: Theme.of(context).colorScheme.primary,
-                            fontSize: 18,
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                      ),
-                      Expanded(
-                        child: ReorderableListView(
-                          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
-                          onReorder: _onReorder,
-                          children: _feds.map(
-                            (selector) => FederationListItem(
-                              key: ValueKey(selector.$1.federationId),
-                              fed: selector.$1,
-                              isRecovering: selector.$2,
-                              data: selector.$3,
-                              onTap: () {
-                                Navigator.of(context).pop();
-                                widget.onFederationSelected(selector.$1, selector.$2);
-                              },
-                              onLeaveFederation: widget.onLeaveFederation,
+              child:
+                  _feds.isEmpty
+                      ? const Center(child: Text('No federations found'))
+                      : Column(
+                        children: [
+                          Container(
+                            height: 80,
+                            padding: const EdgeInsets.all(16),
+                            decoration: BoxDecoration(
+                              color: Colors.grey[900],
+                              border: Border(
+                                bottom: BorderSide(color: Colors.grey.shade800),
+                              ),
                             ),
-                          ).toList(),
-                        ),
+                            alignment: Alignment.centerLeft,
+                            child: Text(
+                              'Federations',
+                              style: TextStyle(
+                                color: Theme.of(context).colorScheme.primary,
+                                fontSize: 18,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                          Expanded(
+                            child: ReorderableListView(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 12,
+                                vertical: 12,
+                              ),
+                              buildDefaultDragHandles: false,
+                              onReorder: _onReorder,
+                              children:
+                                  _feds
+                                      .asMap()
+                                      .entries
+                                      .map(
+                                        (selector) =>
+                                            ReorderableDragStartListener(
+                                              key: ValueKey(selector.key),
+                                              index: selector.key,
+                                              child: FederationListItem(
+                                                key: ValueKey(
+                                                  selector
+                                                      .value
+                                                      .$1
+                                                      .federationId,
+                                                ),
+                                                fed: selector.value.$1,
+                                                isRecovering: selector.value.$2,
+                                                data: selector.value.$3,
+                                                onTap: () {
+                                                  Navigator.of(context).pop();
+                                                  widget.onFederationSelected(
+                                                    selector.value.$1,
+                                                    selector.value.$2,
+                                                  );
+                                                },
+                                                onLeaveFederation:
+                                                    widget.onLeaveFederation,
+                                              ),
+                                            ),
+                                      )
+                                      .toList(),
+                            ),
+                          ),
+                        ],
                       ),
-                    ],
-                  )
             ),
             Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 12),
+              padding: const EdgeInsets.symmetric(
+                horizontal: 12.0,
+                vertical: 12,
+              ),
               child: Material(
                 color: Colors.grey[900],
                 borderRadius: BorderRadius.circular(12),
@@ -195,7 +223,10 @@ class FederationSidebarState extends State<FederationSidebar> {
                     widget.onSettingsPressed();
                   },
                   child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 16,
+                      vertical: 16,
+                    ),
                     child: Row(
                       children: [
                         Icon(
@@ -206,7 +237,9 @@ class FederationSidebarState extends State<FederationSidebar> {
                         const SizedBox(width: 16),
                         Text(
                           'Settings',
-                          style: Theme.of(context).textTheme.bodyLarge!.copyWith(
+                          style: Theme.of(
+                            context,
+                          ).textTheme.bodyLarge!.copyWith(
                             fontWeight: FontWeight.bold,
                             color: Theme.of(context).colorScheme.primary,
                           ),
@@ -246,7 +279,9 @@ class FederationListItem extends StatelessWidget {
       data.guardians!.every((g) => g.version != null);
 
   int get numOnlineGuardians =>
-      data.guardians != null ? data.guardians!.where((g) => g.version != null).length : 0;
+      data.guardians != null
+          ? data.guardians!.where((g) => g.version != null).length
+          : 0;
 
   @override
   Widget build(BuildContext context) {
@@ -299,10 +334,13 @@ class FederationListItem extends StatelessWidget {
                             : data.isLoading
                             ? 'Loading...'
                             : formatBalance(
-                                data.balanceMsats,
-                                false,
-                                context.select<PreferencesProvider, BitcoinDisplay>((prefs) => prefs.bitcoinDisplay),
-                              ),
+                              data.balanceMsats,
+                              false,
+                              context
+                                  .select<PreferencesProvider, BitcoinDisplay>(
+                                    (prefs) => prefs.bitcoinDisplay,
+                                  ),
+                            ),
                         style: Theme.of(context).textTheme.bodyMedium,
                       ),
                       const SizedBox(height: 4),
@@ -353,7 +391,6 @@ class FederationListItem extends StatelessWidget {
                     );
                   },
                 ),
-                const SizedBox(width: 16),
               ],
             ),
           ),


### PR DESCRIPTION
- Fixes the extra padding to the right of the preview button
- Remove rearrange icon on desktop

Tested on mobile device


![rearrange_fix](https://github.com/user-attachments/assets/0ee73aca-40f8-45ea-873f-2c7ce96e178c)
