### PR TITLE
chore(ci): bump ndkVersion in gradle.properties

### DIFF
--- a/.github/actions/android-build/action.yml
+++ b/.github/actions/android-build/action.yml
@@ -107,7 +107,7 @@ runs:
         org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
         android.useAndroidX=true
         android.enableJetifier=true
-        android.ndkVersion=27.0.12077973
+        android.ndkVersion=27.3.13750724
         EOF
 
     - name: Install dependencies


### PR DESCRIPTION
This change doesn't impact CI (which already uses the correct NDK), but prevents considerable confusion when replicating CI builds locally.

GitHub Actions ubuntu-latest (Ubuntu 24.04) runners have NDK 27.3.13750724 pre-installed as `ANDROID_NDK_HOME`. Our `gradle.properties` incorrectly specified 27.0.12077973.

NDK 27.0.12077973 has a CMake architecture detection bug that causes `aws-lc-sys` builds to fail with `"unsupported argument 'armv7-a' to option '-march='"` when targeting aarch64. This was fixed in 27.3.13750724. The bug surfaces when attempting to replicate CI builds locally referenceing this incorrect NDK version. We only recently bumped into this since we hit it after upgrading to fedimint `v0.9.0` which introduced `aws-lc-sys` dependencies.

Runner specs: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
Issue: https://github.com/android/ndk/issues/2049
Fix: https://android.googlesource.com/platform/ndk/+/b390f991e

This update aligns `gradle.properties` with CI's NDK version and supports an upcoming Docker build workflow PR.