### PR TITLE
chore: unify gradle properties in ci, docker, and repo

### DIFF
--- a/.github/actions/android-build/action.yml
+++ b/.github/actions/android-build/action.yml
@@ -95,21 +95,6 @@ runs:
         toolchain: stable
         targets: aarch64-linux-android
 
-    - name: Limit Gradle workers
-      shell: bash
-      run: |
-        mkdir -p android
-        cat > android/gradle.properties <<EOF
-        org.gradle.daemon=false
-        org.gradle.parallel=false
-        org.gradle.configureondemand=true
-        org.gradle.workers.max=2
-        org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
-        android.useAndroidX=true
-        android.enableJetifier=true
-        android.ndkVersion=27.3.13750724
-        EOF
-
     - name: Install dependencies
       shell: bash
       run: |

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,8 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.daemon=false
+org.gradle.parallel=false
+org.gradle.configureondemand=true
+org.gradle.workers.max=2
 android.useAndroidX=true
 android.enableJetifier=true
 android.ndkVersion=27.3.13750724

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -30,20 +30,6 @@ else
 fi
 echo ""
 
-# Setup gradle properties (matching GitHub Actions)
-echo "Configuring Gradle..."
-mkdir -p android
-cat > android/gradle.properties <<EOF
-org.gradle.daemon=false
-org.gradle.parallel=false
-org.gradle.configureondemand=true
-org.gradle.workers.max=2
-org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
-android.useAndroidX=true
-android.enableJetifier=true
-android.ndkVersion=27.3.13750724
-EOF
-
 # Get Flutter dependencies
 echo "Getting Flutter dependencies..."
 flutter pub get


### PR DESCRIPTION
Followup re: https://github.com/fedimint/ecash-app/pull/320#discussion_r2546510747

We can remove duplication of `gradle.properties` in CI and docker, using the more conservative setting in the committed file.

Verified local apk build with

```
CLEAN=1 ./docker/build-apk.sh debug
```