### PR TITLE
chore: only monitor pegin address if operation exists

### DIFF
--- a/rust/ecashapp/src/multimint.rs
+++ b/rust/ecashapp/src/multimint.rs
@@ -743,7 +743,6 @@ impl Multimint {
                                     .await;
                                 }
                             }
-                            tweak_idx = tweak_idx.next();
 
                             let wallet_meta = wallet_op.meta::<WalletOperationMeta>();
                             if let WalletOperationMetaVariant::Deposit {
@@ -773,6 +772,8 @@ impl Multimint {
                                 }
                             }
                         }
+
+                        tweak_idx = tweak_idx.next();
                     }
                 }
             });


### PR DESCRIPTION
I was getting annoyed at seeing this warning in the logs

```
[2026-01-06T18:57:41.325691] [RUST] [INFO] watch_pegin_address(1) failed: Operation not found: 96b4b039_29ccb041

Caused by:
    Operation not found
[2026-01-06T18:57:41.327319] [RUST] [INFO] watch_pegin_address(3) failed: Operation not found: d5ece364_b747ba2c
```

It turns out we do not check if the operation exists before sending the notification to the pegin address monitor. Fix is to just move the code down a bit so that we check if the operation exists first.