### PR TITLE
feat: real time Guardian status

### DIFF
--- a/lib/frb_generated.dart
+++ b/lib/frb_generated.dart
@@ -66,7 +66,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.9.0';
 
   @override
-  int get rustContentHash => -398090574;
+  int get rustContentHash => -1076291757;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -1040,6 +1040,11 @@ abstract class RustLibApi extends BaseApi {
   });
 
   Stream<MultimintEvent> crateSubscribeMultimintEvents();
+
+  Stream<List<PeerStatus>> crateSubscribePeerStatus({
+    String? invite,
+    FederationId? federationId,
+  });
 
   Stream<(int, int)> crateSubscribeRecoveryProgress({
     required FederationId federationId,
@@ -9118,6 +9123,48 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Stream<List<PeerStatus>> crateSubscribePeerStatus({
+    String? invite,
+    FederationId? federationId,
+  }) {
+    final sink = RustStreamSink<List<PeerStatus>>();
+    unawaited(
+      handler.executeNormal(
+        NormalTask(
+          callFfi: (port_) {
+            final serializer = SseSerializer(generalizedFrbRustBinding);
+            sse_encode_StreamSink_list_peer_status_Sse(sink, serializer);
+            sse_encode_opt_String(invite, serializer);
+            sse_encode_opt_box_autoadd_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationId(
+              federationId,
+              serializer,
+            );
+            pdeCallFfi(
+              generalizedFrbRustBinding,
+              serializer,
+              funcId: 209,
+              port: port_,
+            );
+          },
+          codec: SseCodec(
+            decodeSuccessData: sse_decode_unit,
+            decodeErrorData: sse_decode_AnyhowException,
+          ),
+          constMeta: kCrateSubscribePeerStatusConstMeta,
+          argValues: [sink, invite, federationId],
+          apiImpl: this,
+        ),
+      ),
+    );
+    return sink.stream;
+  }
+
+  TaskConstMeta get kCrateSubscribePeerStatusConstMeta => const TaskConstMeta(
+    debugName: "subscribe_peer_status",
+    argNames: ["sink", "invite", "federationId"],
+  );
+
+  @override
   Stream<(int, int)> crateSubscribeRecoveryProgress({
     required FederationId federationId,
     required int moduleId,
@@ -9137,7 +9184,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 209,
+              funcId: 210,
               port: port_,
             );
           },
@@ -9170,7 +9217,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 210,
+            funcId: 211,
             port: port_,
           );
         },
@@ -9209,7 +9256,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 211,
+            funcId: 212,
             port: port_,
           );
         },
@@ -9239,7 +9286,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 212,
+            funcId: 213,
             port: port_,
           );
         },
@@ -9274,7 +9321,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 213,
+            funcId: 214,
             port: port_,
           );
         },
@@ -9318,7 +9365,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 214,
+            funcId: 215,
             port: port_,
           );
         },
@@ -9348,7 +9395,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 215,
+            funcId: 216,
             port: port_,
           );
         },
@@ -10170,6 +10217,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  RustStreamSink<List<PeerStatus>> dco_decode_StreamSink_list_peer_status_Sse(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    throw UnimplementedError();
+  }
+
+  @protected
   RustStreamSink<MultimintEvent> dco_decode_StreamSink_multimint_event_Sse(
     dynamic raw,
   ) {
@@ -10628,6 +10683,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  List<PeerStatus> dco_decode_list_peer_status(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>).map(dco_decode_peer_status).toList();
+  }
+
+  @protected
   Uint8List dco_decode_list_prim_u_8_strict(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw as Uint8List;
@@ -11004,6 +11065,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       gateway: dco_decode_String(arr[4]),
       amountWithFees: dco_decode_u_64(arr[5]),
       isLnv2: dco_decode_bool(arr[6]),
+    );
+  }
+
+  @protected
+  PeerStatus dco_decode_peer_status(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 3)
+      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    return PeerStatus(
+      peerId: dco_decode_u_16(arr[0]),
+      name: dco_decode_String(arr[1]),
+      online: dco_decode_bool(arr[2]),
     );
   }
 
@@ -12240,6 +12314,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  RustStreamSink<List<PeerStatus>> sse_decode_StreamSink_list_peer_status_Sse(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    throw UnimplementedError('Unreachable ()');
+  }
+
+  @protected
   RustStreamSink<MultimintEvent> sse_decode_StreamSink_multimint_event_Sse(
     SseDeserializer deserializer,
   ) {
@@ -12791,6 +12873,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  List<PeerStatus> sse_decode_list_peer_status(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <PeerStatus>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_peer_status(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
   Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var len_ = sse_decode_i_32(deserializer);
@@ -13302,6 +13396,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       amountWithFees: var_amountWithFees,
       isLnv2: var_isLnv2,
     );
+  }
+
+  @protected
+  PeerStatus sse_decode_peer_status(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_peerId = sse_decode_u_16(deserializer);
+    var var_name = sse_decode_String(deserializer);
+    var var_online = sse_decode_bool(deserializer);
+    return PeerStatus(peerId: var_peerId, name: var_name, online: var_online);
   }
 
   @protected
@@ -14569,6 +14672,23 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_StreamSink_list_peer_status_Sse(
+    RustStreamSink<List<PeerStatus>> self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(
+      self.setupAndSerialize(
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_list_peer_status,
+          decodeErrorData: sse_decode_AnyhowException,
+        ),
+      ),
+      serializer,
+    );
+  }
+
+  @protected
   void sse_encode_StreamSink_multimint_event_Sse(
     RustStreamSink<MultimintEvent> self,
     SseSerializer serializer,
@@ -15096,6 +15216,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_list_peer_status(
+    List<PeerStatus> self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_peer_status(item, serializer);
+    }
+  }
+
+  @protected
   void sse_encode_list_prim_u_8_strict(
     Uint8List self,
     SseSerializer serializer,
@@ -15572,6 +15704,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_String(self.gateway, serializer);
     sse_encode_u_64(self.amountWithFees, serializer);
     sse_encode_bool(self.isLnv2, serializer);
+  }
+
+  @protected
+  void sse_encode_peer_status(PeerStatus self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_u_16(self.peerId, serializer);
+    sse_encode_String(self.name, serializer);
+    sse_encode_bool(self.online, serializer);
   }
 
   @protected

--- a/lib/frb_generated.io.dart
+++ b/lib/frb_generated.io.dart
@@ -507,6 +507,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  RustStreamSink<List<PeerStatus>> dco_decode_StreamSink_list_peer_status_Sse(
+    dynamic raw,
+  );
+
+  @protected
   RustStreamSink<MultimintEvent> dco_decode_StreamSink_multimint_event_Sse(
     dynamic raw,
   );
@@ -686,6 +691,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<NostrProfile> dco_decode_list_nostr_profile(dynamic raw);
 
   @protected
+  List<PeerStatus> dco_decode_list_peer_status(dynamic raw);
+
+  @protected
   Uint8List dco_decode_list_prim_u_8_strict(dynamic raw);
 
   @protected
@@ -805,6 +813,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   PaymentPreview dco_decode_payment_preview(dynamic raw);
+
+  @protected
+  PeerStatus dco_decode_peer_status(dynamic raw);
 
   @protected
   (Bolt11Invoice, OperationId)
@@ -1336,6 +1347,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  RustStreamSink<List<PeerStatus>> sse_decode_StreamSink_list_peer_status_Sse(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   RustStreamSink<MultimintEvent> sse_decode_StreamSink_multimint_event_Sse(
     SseDeserializer deserializer,
   );
@@ -1545,6 +1561,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  List<PeerStatus> sse_decode_list_peer_status(SseDeserializer deserializer);
+
+  @protected
   Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer);
 
   @protected
@@ -1676,6 +1695,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   PaymentPreview sse_decode_payment_preview(SseDeserializer deserializer);
+
+  @protected
+  PeerStatus sse_decode_peer_status(SseDeserializer deserializer);
 
   @protected
   (Bolt11Invoice, OperationId)
@@ -2282,6 +2304,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_StreamSink_list_peer_status_Sse(
+    RustStreamSink<List<PeerStatus>> self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_StreamSink_multimint_event_Sse(
     RustStreamSink<MultimintEvent> self,
     SseSerializer serializer,
@@ -2533,6 +2561,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_list_peer_status(
+    List<PeerStatus> self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_list_prim_u_8_strict(
     Uint8List self,
     SseSerializer serializer,
@@ -2702,6 +2736,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     PaymentPreview self,
     SseSerializer serializer,
   );
+
+  @protected
+  void sse_encode_peer_status(PeerStatus self, SseSerializer serializer);
 
   @protected
   void

--- a/lib/frb_generated.web.dart
+++ b/lib/frb_generated.web.dart
@@ -509,6 +509,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  RustStreamSink<List<PeerStatus>> dco_decode_StreamSink_list_peer_status_Sse(
+    dynamic raw,
+  );
+
+  @protected
   RustStreamSink<MultimintEvent> dco_decode_StreamSink_multimint_event_Sse(
     dynamic raw,
   );
@@ -688,6 +693,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<NostrProfile> dco_decode_list_nostr_profile(dynamic raw);
 
   @protected
+  List<PeerStatus> dco_decode_list_peer_status(dynamic raw);
+
+  @protected
   Uint8List dco_decode_list_prim_u_8_strict(dynamic raw);
 
   @protected
@@ -807,6 +815,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   PaymentPreview dco_decode_payment_preview(dynamic raw);
+
+  @protected
+  PeerStatus dco_decode_peer_status(dynamic raw);
 
   @protected
   (Bolt11Invoice, OperationId)
@@ -1338,6 +1349,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  RustStreamSink<List<PeerStatus>> sse_decode_StreamSink_list_peer_status_Sse(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   RustStreamSink<MultimintEvent> sse_decode_StreamSink_multimint_event_Sse(
     SseDeserializer deserializer,
   );
@@ -1547,6 +1563,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  List<PeerStatus> sse_decode_list_peer_status(SseDeserializer deserializer);
+
+  @protected
   Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer);
 
   @protected
@@ -1678,6 +1697,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   PaymentPreview sse_decode_payment_preview(SseDeserializer deserializer);
+
+  @protected
+  PeerStatus sse_decode_peer_status(SseDeserializer deserializer);
 
   @protected
   (Bolt11Invoice, OperationId)
@@ -2284,6 +2306,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_StreamSink_list_peer_status_Sse(
+    RustStreamSink<List<PeerStatus>> self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_StreamSink_multimint_event_Sse(
     RustStreamSink<MultimintEvent> self,
     SseSerializer serializer,
@@ -2535,6 +2563,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_list_peer_status(
+    List<PeerStatus> self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_list_prim_u_8_strict(
     Uint8List self,
     SseSerializer serializer,
@@ -2704,6 +2738,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     PaymentPreview self,
     SseSerializer serializer,
   );
+
+  @protected
+  void sse_encode_peer_status(PeerStatus self, SseSerializer serializer);
 
   @protected
   void

--- a/lib/lib.dart
+++ b/lib/lib.dart
@@ -435,6 +435,14 @@ Future<(String, String)> claimRandomLnAddress({
 Future<void> leaveFederation({required FederationId federationId}) =>
     RustLib.instance.api.crateLeaveFederation(federationId: federationId);
 
+Stream<List<PeerStatus>> subscribePeerStatus({
+  String? invite,
+  FederationId? federationId,
+}) => RustLib.instance.api.crateSubscribePeerStatus(
+  invite: invite,
+  federationId: federationId,
+);
+
 /// Verify a NIP-05 identifier and return the associated npub
 Future<String> verifyNip05({required String nip05Id}) =>
     RustLib.instance.api.crateVerifyNip05(nip05Id: nip05Id);

--- a/lib/multimint.dart
+++ b/lib/multimint.dart
@@ -12,7 +12,8 @@ part 'multimint.freezed.dart';
 
 // These functions are ignored because they are not marked as `pub`: `await_receive_lnv1`, `await_receive_lnv2`, `await_send_lnv1`, `await_send_lnv2`, `backup`, `build_client`, `cache_btc_price`, `cache_federation_meta`, `compute_receive_amount`, `compute_send_amount`, `finish_active_subscriptions`, `from_peg_out_fees`, `get_client_database`, `get_ecash_amount_from_meta`, `get_lnv1_amount_from_meta`, `get_lnv1_receive_tx`, `get_lnv1_send_tx`, `get_lnv2_amount_from_meta`, `get_or_build_temp_client`, `get_recurringd_federations`, `get_url`, `init_recovery_progress_cache`, `invoice_routes_back_to_federation`, `lnv1_select_gateway`, `lnv1_update_gateway_cache`, `lnv2_select_gateway`, `load_clients`, `monitor_all_unused_pegin_addresses`, `pay_lnv1`, `pay_lnv2`, `receive_amount_after_fees`, `receive_lnv1`, `receive_lnv2`, `remove_existing_ln_address`, `remove_recovery_progress_cache`, `spawn_await_ecash_reissue`, `spawn_await_ecash_send`, `spawn_await_receive`, `spawn_await_recurringd_receive`, `spawn_await_send`, `spawn_cache_task`, `spawn_pegin_address_watcher`, `spawn_recovery_progress`, `spawn_recurring_invoice_listener`, `spend_until_exact_amount`, `update_recovery_progress_cache`, `wait_for_recovery`, `watch_pegin_address`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `ClientType`, `LNAddressRegisterRequest`, `LNAddressRemoveRequest`, `OnChainWithdrawalMeta`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `consensus_decode_partial_from_finite_reader`, `consensus_decode_partial_from_finite_reader`, `consensus_decode_partial_from_finite_reader`, `consensus_encode`, `consensus_encode`, `consensus_encode`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `consensus_decode_partial_from_finite_reader`, `consensus_decode_partial_from_finite_reader`, `consensus_decode_partial_from_finite_reader`, `consensus_encode`, `consensus_encode`, `consensus_encode`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`
+// These functions have error during generation (see debug logs or enable `stop_on_error: true` for more details): `subscribe_peer_status`
 
 // Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<Amount>>
 abstract class Amount implements RustOpaqueInterface {}
@@ -632,6 +633,30 @@ class PaymentPreview {
           gateway == other.gateway &&
           amountWithFees == other.amountWithFees &&
           isLnv2 == other.isLnv2;
+}
+
+class PeerStatus {
+  final int peerId;
+  final String name;
+  final bool online;
+
+  const PeerStatus({
+    required this.peerId,
+    required this.name,
+    required this.online,
+  });
+
+  @override
+  int get hashCode => peerId.hashCode ^ name.hashCode ^ online.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is PeerStatus &&
+          runtimeType == other.runtimeType &&
+          peerId == other.peerId &&
+          name == other.name &&
+          online == other.online;
 }
 
 class Transaction {

--- a/lib/screens/dashboard.dart
+++ b/lib/screens/dashboard.dart
@@ -27,8 +27,14 @@ import 'package:ecashapp/widgets/transactions_list.dart';
 class Dashboard extends StatefulWidget {
   final FederationSelector fed;
   final bool recovering;
+  final VoidCallback? onFederationTap;
 
-  const Dashboard({super.key, required this.fed, required this.recovering});
+  const Dashboard({
+    super.key,
+    required this.fed,
+    required this.recovering,
+    this.onFederationTap,
+  });
 
   @override
   _DashboardState createState() => _DashboardState();
@@ -304,7 +310,11 @@ class _DashboardState extends State<Dashboard> {
         padding: const EdgeInsets.all(24),
         child: Column(
           children: [
-            DashboardHeader(name: name, network: widget.fed.network),
+            DashboardHeader(
+              name: name,
+              network: widget.fed.network,
+              onTap: widget.onFederationTap,
+            ),
             if (_lnAddressConfig != null) ...[
               const SizedBox(height: 8),
               GestureDetector(

--- a/lib/widgets/dashboard_header.dart
+++ b/lib/widgets/dashboard_header.dart
@@ -3,52 +3,63 @@ import 'package:flutter/material.dart';
 class DashboardHeader extends StatelessWidget {
   final String name;
   final String? network;
+  final VoidCallback? onTap;
 
-  const DashboardHeader({super.key, required this.name, this.network});
+  const DashboardHeader({
+    super.key,
+    required this.name,
+    this.network,
+    this.onTap,
+  });
 
   @override
   Widget build(BuildContext context) {
-    return ShaderMask(
-      shaderCallback:
-          (bounds) => LinearGradient(
-            colors: [
-              Theme.of(context).colorScheme.primary,
-              Theme.of(context).colorScheme.secondary,
-            ],
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-          ).createShader(Rect.fromLTWH(0, 0, bounds.width, bounds.height)),
-      child: Column(
-        children: [
-          Text(
-            name.toUpperCase(),
-            style: Theme.of(context).textTheme.headlineMedium?.copyWith(
-              fontWeight: FontWeight.w900,
-              letterSpacing: 2,
-              color: Colors.white,
-              shadows: [
-                Shadow(
-                  blurRadius: 10,
-                  color: Theme.of(context).colorScheme.primary.withOpacity(0.5),
-                  offset: const Offset(0, 2),
-                ),
+    return GestureDetector(
+      onTap: onTap,
+      child: ShaderMask(
+        shaderCallback:
+            (bounds) => LinearGradient(
+              colors: [
+                Theme.of(context).colorScheme.primary,
+                Theme.of(context).colorScheme.secondary,
               ],
-            ),
-            textAlign: TextAlign.center,
-          ),
-          if (network != null && network!.toLowerCase() != 'bitcoin')
-            Padding(
-              padding: const EdgeInsets.only(top: 8.0),
-              child: Text(
-                "This is a test network and is not worth anything.",
-                style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: Theme.of(context).colorScheme.secondary,
-                  fontStyle: FontStyle.italic,
-                ),
-                textAlign: TextAlign.center,
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+            ).createShader(Rect.fromLTWH(0, 0, bounds.width, bounds.height)),
+        child: Column(
+          children: [
+            Text(
+              name.toUpperCase(),
+              style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                fontWeight: FontWeight.w900,
+                letterSpacing: 2,
+                color: Colors.white,
+                shadows: [
+                  Shadow(
+                    blurRadius: 10,
+                    color: Theme.of(
+                      context,
+                    ).colorScheme.primary.withOpacity(0.5),
+                    offset: const Offset(0, 2),
+                  ),
+                ],
               ),
+              textAlign: TextAlign.center,
             ),
-        ],
+            if (network != null && network!.toLowerCase() != 'bitcoin')
+              Padding(
+                padding: const EdgeInsets.only(top: 8.0),
+                child: Text(
+                  "This is a test network and is not worth anything.",
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context).colorScheme.secondary,
+                    fontStyle: FontStyle.italic,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+          ],
+        ),
       ),
     );
   }

--- a/rust/ecashapp/src/frb_generated.rs
+++ b/rust/ecashapp/src/frb_generated.rs
@@ -42,7 +42,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.9.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -398090574;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1076291757;
 
 // Section: executor
 
@@ -11379,6 +11379,49 @@ fn wire__crate__subscribe_multimint_events_impl(
         },
     )
 }
+fn wire__crate__subscribe_peer_status_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "subscribe_peer_status",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_sink = <StreamSink<
+                Vec<crate::multimint::PeerStatus>,
+                flutter_rust_bridge::for_generated::SseCodec,
+            >>::sse_decode(&mut deserializer);
+            let api_invite = <Option<String>>::sse_decode(&mut deserializer);
+            let api_federation_id = <Option<FederationId>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                    (move || async move {
+                        let output_ok =
+                            crate::subscribe_peer_status(api_sink, api_invite, api_federation_id)
+                                .await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
 fn wire__crate__subscribe_recovery_progress_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -12256,6 +12299,16 @@ impl SseDecode
 }
 
 impl SseDecode
+    for StreamSink<Vec<crate::multimint::PeerStatus>, flutter_rust_bridge::for_generated::SseCodec>
+{
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <String>::sse_decode(deserializer);
+        return StreamSink::deserialize(inner);
+    }
+}
+
+impl SseDecode
     for StreamSink<crate::multimint::MultimintEvent, flutter_rust_bridge::for_generated::SseCodec>
 {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -12666,6 +12719,18 @@ impl SseDecode for Vec<crate::nostr::NostrProfile> {
         let mut ans_ = vec![];
         for idx_ in 0..len_ {
             ans_.push(<crate::nostr::NostrProfile>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<crate::multimint::PeerStatus> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<crate::multimint::PeerStatus>::sse_decode(deserializer));
         }
         return ans_;
     }
@@ -13169,6 +13234,20 @@ impl SseDecode for crate::multimint::PaymentPreview {
             gateway: var_gateway,
             amount_with_fees: var_amountWithFees,
             is_lnv2: var_isLnv2,
+        };
+    }
+}
+
+impl SseDecode for crate::multimint::PeerStatus {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_peerId = <u16>::sse_decode(deserializer);
+        let mut var_name = <String>::sse_decode(deserializer);
+        let mut var_online = <bool>::sse_decode(deserializer);
+        return crate::multimint::PeerStatus {
+            peer_id: var_peerId,
+            name: var_name,
+            online: var_online,
         };
     }
 }
@@ -13938,13 +14017,14 @@ fn pde_ffi_dispatcher_primary_impl(
         206 => wire__crate__set_nwc_connection_info_impl(port, ptr, rust_vec_len, data_len),
         207 => wire__crate__subscribe_deposits_impl(port, ptr, rust_vec_len, data_len),
         208 => wire__crate__subscribe_multimint_events_impl(port, ptr, rust_vec_len, data_len),
-        209 => wire__crate__subscribe_recovery_progress_impl(port, ptr, rust_vec_len, data_len),
-        210 => wire__crate__sync_contacts_impl(port, ptr, rust_vec_len, data_len),
-        211 => wire__crate__transactions_impl(port, ptr, rust_vec_len, data_len),
-        212 => wire__crate__verify_nip05_impl(port, ptr, rust_vec_len, data_len),
-        213 => wire__crate__wallet_summary_impl(port, ptr, rust_vec_len, data_len),
-        214 => wire__crate__withdraw_to_address_impl(port, ptr, rust_vec_len, data_len),
-        215 => wire__crate__word_list_impl(port, ptr, rust_vec_len, data_len),
+        209 => wire__crate__subscribe_peer_status_impl(port, ptr, rust_vec_len, data_len),
+        210 => wire__crate__subscribe_recovery_progress_impl(port, ptr, rust_vec_len, data_len),
+        211 => wire__crate__sync_contacts_impl(port, ptr, rust_vec_len, data_len),
+        212 => wire__crate__transactions_impl(port, ptr, rust_vec_len, data_len),
+        213 => wire__crate__verify_nip05_impl(port, ptr, rust_vec_len, data_len),
+        214 => wire__crate__wallet_summary_impl(port, ptr, rust_vec_len, data_len),
+        215 => wire__crate__withdraw_to_address_impl(port, ptr, rust_vec_len, data_len),
+        216 => wire__crate__word_list_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -15290,6 +15370,25 @@ impl flutter_rust_bridge::IntoIntoDart<crate::multimint::PaymentPreview>
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::multimint::PeerStatus {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.peer_id.into_into_dart().into_dart(),
+            self.name.into_into_dart().into_dart(),
+            self.online.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for crate::multimint::PeerStatus {}
+impl flutter_rust_bridge::IntoIntoDart<crate::multimint::PeerStatus>
+    for crate::multimint::PeerStatus
+{
+    fn into_into_dart(self) -> crate::multimint::PeerStatus {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::multimint::Transaction {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
@@ -15865,6 +15964,15 @@ impl SseEncode
 }
 
 impl SseEncode
+    for StreamSink<Vec<crate::multimint::PeerStatus>, flutter_rust_bridge::for_generated::SseCodec>
+{
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        unimplemented!("")
+    }
+}
+
+impl SseEncode
     for StreamSink<crate::multimint::MultimintEvent, flutter_rust_bridge::for_generated::SseCodec>
 {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -16212,6 +16320,16 @@ impl SseEncode for Vec<crate::nostr::NostrProfile> {
         <i32>::sse_encode(self.len() as _, serializer);
         for item in self {
             <crate::nostr::NostrProfile>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<crate::multimint::PeerStatus> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <crate::multimint::PeerStatus>::sse_encode(item, serializer);
         }
     }
 }
@@ -16644,6 +16762,15 @@ impl SseEncode for crate::multimint::PaymentPreview {
         <String>::sse_encode(self.gateway, serializer);
         <u64>::sse_encode(self.amount_with_fees, serializer);
         <bool>::sse_encode(self.is_lnv2, serializer);
+    }
+}
+
+impl SseEncode for crate::multimint::PeerStatus {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <u16>::sse_encode(self.peer_id, serializer);
+        <String>::sse_encode(self.name, serializer);
+        <bool>::sse_encode(self.online, serializer);
     }
 }
 


### PR DESCRIPTION
It always bothered me that in order to determine if a peer is online or offline we needed to wait 30 seconds and manually refresh the UI. With the new API in `v0.10.0`, we no longer need to do this.

This PR:
 - Adds a rust API for streaming the `PeerStatus`. If the user hasn't joined the federation yet, it is a stream with a single event.
 - Updates the federation preview and sidebar widgets to use the new API for online status.
 - Adds dots at the top of the dashboard for easy access of determining how many peers are online
 - Makes the dots and the federation name clickable, to bring up the federation preview.

Below is small video of what it looks like to manually kill guardians in a devimint federation.
[Kooha-2026-01-28-14-13-41.webm](https://github.com/user-attachments/assets/7d13180f-0eb9-409f-88fe-de7db90e99d5)
