### PR TITLE
fix: leaving federation takes a long time

### DIFF
--- a/rust/ecashapp/src/multimint.rs
+++ b/rust/ecashapp/src/multimint.rs
@@ -857,10 +857,11 @@ impl Multimint {
                             }
                         }
 
-                        if let Some(client) = self_copy.clients.read().await.get(&federation_id) {
-                            if !client.has_pending_recoveries() {
-                                self_copy.cache_federation_meta(client.clone(), now).await;
-                            }
+                        let client = self_copy.clients.read().await.get(&federation_id).cloned();
+                        let Some(client) = client else { continue };
+
+                        if !client.has_pending_recoveries() {
+                            self_copy.cache_federation_meta(client.clone(), now).await;
                         }
                     }
 


### PR DESCRIPTION
We have a bug where it sometimes takes a long time to leave a federation. This is happening because the `leave_federation` function is competing for a lock with the caching thread. This is not necessary, we can just copy out the client and limit the amount of time where the lock is under contention. This is safe to do because we don't delete any client data, just the metadata entry when leaving. 