### PR TITLE
chore: update deprecated `value` to `initialValue`

### DIFF
--- a/lib/ln_address.dart
+++ b/lib/ln_address.dart
@@ -228,7 +228,7 @@ class _LightningAddressScreenState extends State<LightningAddressScreen> {
         if (_domains.isNotEmpty) ...[
           DropdownButtonFormField<FederationSelector>(
             decoration: const InputDecoration(labelText: 'Select a Federation'),
-            value: _selectedFederation,
+            initialValue: _selectedFederation,
             items:
                 feds
                     .map(
@@ -260,7 +260,7 @@ class _LightningAddressScreenState extends State<LightningAddressScreen> {
                 flex: 3,
                 child: DropdownButtonFormField<String>(
                   decoration: const InputDecoration(labelText: 'Domain'),
-                  value: _selectedDomain,
+                  initialValue: _selectedDomain,
                   items:
                       _domains
                           .map(

--- a/lib/nwc.dart
+++ b/lib/nwc.dart
@@ -321,7 +321,7 @@ class _NostrWalletConnectState extends State<NostrWalletConnect> {
       children: [
         DropdownButtonFormField<FederationSelector>(
           decoration: const InputDecoration(labelText: 'Select a Federation'),
-          value: _selectedFederation,
+          initialValue: _selectedFederation,
           items:
               feds
                   .map(
@@ -348,7 +348,7 @@ class _NostrWalletConnectState extends State<NostrWalletConnect> {
         const SizedBox(height: 16),
         DropdownButtonFormField<String>(
           decoration: const InputDecoration(labelText: 'Select a Relay'),
-          value: _selectedRelay,
+          initialValue: _selectedRelay,
           items:
               _relays.map((relay) {
                 final (uri, connected) = relay;


### PR DESCRIPTION
This is cleanup necessary for the latest release.

Flutter 3.38.3 deprecated `value` in DropdownButtonFormField in favor of `initialValue` (after v3.33.0). The previous `value` usage was a workaround from PR #330 when CI was on Flutter 3.32.4, which didn't have `initialValue` yet.