### PR TITLE
refactor: unify CI and Docker AppImage builds into shared script

### DIFF
--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -24,29 +24,12 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y clang cmake ninja-build libgtk-3-dev
-      - name: Build Rust library
+      - name: Install appimagetool
         run: |
-          cargo build --release --manifest-path rust/ecashapp/Cargo.toml --target-dir rust/ecashapp/target
-          mkdir -p build/linux/x64/release/bundle/lib
-          cp rust/ecashapp/target/release/libecashapp.so build/linux/x64/release/bundle/lib/
+          sudo wget -q https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool
+          sudo chmod +x /usr/local/bin/appimagetool
       - name: Build AppImage
-        run: |
-          flutter pub get
-          flutter build linux --release
-          wget -q https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage -O appimagetool
-          chmod +x appimagetool
-          mkdir -p AppDir/usr/share/icons/hicolor/512x512/apps
-          mkdir -p AppDir/usr/share/metainfo
-          cp -r build/linux/x64/release/bundle/* AppDir/
-          cp linux/runner/ecash-app.png AppDir/usr/share/icons/hicolor/512x512/apps/
-          cp linux/runner/ecash-app.png AppDir/ecash-app.png
-          mkdir -p AppDir/usr/share/applications
-          cp linux/runner/org.fedimint.app.desktop AppDir/
-          cp linux/runner/org.fedimint.app.desktop AppDir/usr/share/applications/
-          cp linux/appstream/org.fedimint.app.appdata.xml AppDir/usr/share/metainfo/
-          ln -sf ecashapp AppDir/AppRun
-          VERSION=$(grep "^version:" pubspec.yaml | cut -d" " -f2)
-          ARCH=x86_64 ./appimagetool AppDir "ecash-app-${VERSION}-x86_64.AppImage"
+        run: ./scripts/package-linux.sh
       - name: Upload to Release
         uses: ncipollo/release-action@v1
         with:

--- a/docker/build-appimage.sh
+++ b/docker/build-appimage.sh
@@ -40,25 +40,7 @@ docker run --rm \
     -e CARGO_HOME="/cargo-cache" \
     -e HOME="/workspace" \
     $IMAGE_NAME \
-    bash -c '
-        rm -rf build/linux AppDir *.AppImage
-        cargo build --release --manifest-path rust/ecashapp/Cargo.toml --target-dir rust/ecashapp/target
-        flutter pub get
-        flutter build linux --release
-        cp rust/ecashapp/target/release/libecashapp.so build/linux/x64/release/bundle/lib/
-        mkdir -p AppDir/usr/share/icons/hicolor/512x512/apps
-        mkdir -p AppDir/usr/share/metainfo
-        mkdir -p AppDir/usr/share/applications
-        cp -r build/linux/x64/release/bundle/* AppDir/
-        cp linux/runner/ecash-app.png AppDir/usr/share/icons/hicolor/512x512/apps/
-        cp linux/runner/ecash-app.png AppDir/ecash-app.png
-        cp linux/runner/org.fedimint.app.desktop AppDir/
-        cp linux/runner/org.fedimint.app.desktop AppDir/usr/share/applications/
-        cp linux/appstream/org.fedimint.app.appdata.xml AppDir/usr/share/metainfo/
-        ln -sf ecashapp AppDir/AppRun
-        VERSION=$(grep "^version:" pubspec.yaml | cut -d" " -f2)
-        ARCH=x86_64 appimagetool AppDir "ecash-app-${VERSION}-x86_64.AppImage"
-    '
+    bash scripts/package-linux.sh
 
 # Restore host's .dart_tool
 rm -rf "$PROJECT_ROOT/.dart_tool"

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+
+# Clean previous build artifacts
+rm -rf build/linux AppDir *.AppImage
+
+# Build Rust library
+cargo build --release --manifest-path rust/ecashapp/Cargo.toml --target-dir rust/ecashapp/target
+
+# Build Flutter app
+flutter pub get
+flutter build linux --release
+
+# Copy Rust library AFTER flutter build (flutter build wipes bundle/lib/)
+cp rust/ecashapp/target/release/libecashapp.so build/linux/x64/release/bundle/lib/
+
+# Create AppDir structure
+mkdir -p AppDir/usr/share/icons/hicolor/512x512/apps
+mkdir -p AppDir/usr/share/metainfo
+mkdir -p AppDir/usr/share/applications
+
+# Copy bundle and assets
+cp -r build/linux/x64/release/bundle/* AppDir/
+cp linux/runner/ecash-app.png AppDir/usr/share/icons/hicolor/512x512/apps/
+cp linux/runner/ecash-app.png AppDir/ecash-app.png
+cp linux/runner/org.fedimint.app.desktop AppDir/
+cp linux/runner/org.fedimint.app.desktop AppDir/usr/share/applications/
+cp linux/appstream/org.fedimint.app.appdata.xml AppDir/usr/share/metainfo/
+ln -sf ecashapp AppDir/AppRun
+
+# Package AppImage
+VERSION=$(grep "^version:" pubspec.yaml | cut -d" " -f2)
+ARCH=x86_64 appimagetool AppDir "ecash-app-${VERSION}-x86_64.AppImage"


### PR DESCRIPTION
Extracts build logic into scripts/package-linux.sh, fixing a bug where CI copied libecashapp.so before `flutter build linux --release`, which would wipe it.

The rc.1 AppImage was 15MB (missing .so) vs 70MB (working). This ensures both CI and Docker use identical build order.