### PR TITLE
chore: refactor version code calculation

### DIFF
--- a/.github/actions/android-build/action.yml
+++ b/.github/actions/android-build/action.yml
@@ -170,37 +170,26 @@ runs:
       id: version
       shell: bash
       run: |
-        VERSION_NAME=$(grep '^version:' pubspec.yaml | sed 's/version: //' | cut -d'+' -f1)
+        FULL_VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //')
+        VERSION_NAME=$(echo "$FULL_VERSION" | cut -d'+' -f1)
 
         if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
-          # extract base version without pre-release suffix
-          BASE_VERSION=$(echo $VERSION_NAME | sed 's/-rc\..*//' | sed 's/-alpha.*//')
-          MAJOR=$(echo $BASE_VERSION | cut -d. -f1)
-          MINOR=$(echo $BASE_VERSION | cut -d. -f2)
-          PATCH=$(echo $BASE_VERSION | cut -d. -f3)
-
-          # calculate version code from semantic version
-          # inspired by https://github.com/ReactiveCircus/app-versioning
-          # verified by https://gist.github.com/bradleystachurski/2262b1e5a835489702e961f645f4f547
-          BASE_CODE=$((MAJOR * 1000000 + MINOR * 10000 + PATCH * 100))
-
-          if [[ "$VERSION_NAME" == *"-rc."* ]]; then
-            RC_NUM=$(echo $VERSION_NAME | sed 's/.*-rc\.//')
-            VERSION_CODE=$((BASE_CODE + RC_NUM))
-          else
-            # final release gets +90 to be above all RCs (room for 89 RCs)
-            VERSION_CODE=$((BASE_CODE + 90))
+          # For tagged releases, the release script already set version+code in pubspec.yaml
+          VERSION_CODE=$(echo "$FULL_VERSION" | cut -d'+' -f2)
+          if [[ "$VERSION_CODE" == "$VERSION_NAME" ]]; then
+            echo "Error: pubspec.yaml version is missing +versionCode. Use scripts/release.sh to create releases."
+            exit 1
           fi
         else
-          # for master builds, use run number
+          # For master builds, use run number
           VERSION_CODE=$GITHUB_RUN_NUMBER
+          sed -i "s/version: .*/version: $VERSION_NAME+$VERSION_CODE/" pubspec.yaml
         fi
 
         echo "VERSION_CODE=$VERSION_CODE" >> $GITHUB_ENV
         echo "VERSION_NAME=$VERSION_NAME" >> $GITHUB_ENV
         echo "version_code=$VERSION_CODE" >> $GITHUB_OUTPUT
         echo "version_name=$VERSION_NAME" >> $GITHUB_OUTPUT
-        sed -i "s/version: .*/version: $VERSION_NAME+$VERSION_CODE/" pubspec.yaml
 
     - name: Build Flutter APK
       shell: bash

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -3,33 +3,26 @@
 ## Release Candidates
 
 - Create release branch (if new major/minor): `git checkout -b releases/vX.Y`
-- Update versions:
-  - `pubspec.yaml`: `version: X.Y.Z-rc.N`
-  - `rust/ecashapp/Cargo.toml`: `version = "X.Y.Z-rc.N"`
-  - `just build-linux`
-  - `flutter analyze`
-- Commit: `git commit -am "chore: bump version to vX.Y.Z-rc.N"`
-- Push: `git push upstream releases/vX.Y`
-- Tag: `git tag -a -s vX.Y.Z-rc.N`
-- Push tag: `git push upstream vX.Y.Z-rc.N`
+- Run the release script: `./scripts/release.sh X.Y.Z-rc.N`
+  - Updates `pubspec.yaml` to `version: X.Y.Z-rc.N+VCODE`
+  - Updates `rust/ecashapp/Cargo.toml` to `version = "X.Y.Z-rc.N"`
+  - Commits and creates tag `vX.Y.Z-rc.N`
+- Verify build: `just build-linux` and `flutter analyze`
+- Push: `git push upstream releases/vX.Y && git push upstream vX.Y.Z-rc.N`
 - Verify GitHub release created with APK and AppImage
 
 ## Final Release
 
 - On release branch: `git checkout releases/vX.Y`
 - Create final release branch: `git checkout -b releases/vX.Y.Z`
-- Update versions:
-  - `pubspec.yaml`: `version: X.Y.Z`
-  - `rust/ecashapp/Cargo.toml`: `version = "X.Y.Z"`
-  - `just build-linux`
-  - `flutter analyze`
-- Commit: `git commit -am "chore: bump version to vX.Y.Z"`
-- Add appstream release entry:
-  - `linux/appstream/org.fedimint.app.appdata.xml`: Add `<release version="X.Y.Z" date="YYYY-MM-DD" />` entry
-  - Commit: `git commit -am "chore: add appstream release entry for vX.Y.Z"`
-- Push: `git push upstream releases/vX.Y.Z`
-- Tag: `git tag -a -s vX.Y.Z`
-- Push tag: `git push upstream vX.Y.Z`
+- Add F-Droid changelog: `metadata/en-US/changelogs/VCODE.txt` (max 500 chars)
+- Commit any manual changes: `git commit -am "chore: prepare vX.Y.Z release"`
+- Run the release script: `./scripts/release.sh X.Y.Z`
+  - Updates `pubspec.yaml` to `version: X.Y.Z+VCODE`
+  - Updates `rust/ecashapp/Cargo.toml` to `version = "X.Y.Z"`
+  - Adds appstream release entry to `linux/appstream/org.fedimint.app.appdata.xml`
+  - Commits and creates tag `vX.Y.Z`
+- Push: `git push upstream releases/vX.Y.Z && git push upstream vX.Y.Z`
 - Verify GitHub release created with APK and AppImage
 
 ## Post-Release
@@ -43,5 +36,12 @@
 
 ## Version Code Reference
 
-- RC: `major*1000000 + minor*10000 + patch*100 + rc_num`
-- Final: `major*1000000 + minor*10000 + patch*100 + 90`
+The version code (VCODE) is calculated by `scripts/release.sh` and included in `pubspec.yaml` after a `+` suffix. This is required for F-Droid auto-update detection.
+
+- RC: `VCODE = major*1000000 + minor*10000 + patch*100 + rc_num`
+- Final: `VCODE = major*1000000 + minor*10000 + patch*100 + 90`
+
+Examples:
+- `0.5.0` → `version: 0.5.0+50090`
+- `0.5.0-rc.1` → `version: 0.5.0-rc.1+50001`
+- `1.0.0` → `version: 1.0.0+1000090`

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -e
+
+# Release script for Ecash App
+# Calculates versionCode, updates pubspec.yaml and Cargo.toml, commits, and tags.
+#
+# Usage:
+#   ./scripts/release.sh <version>
+#
+# Examples:
+#   ./scripts/release.sh 0.5.0        # → version: 0.5.0+50090, tag v0.5.0
+#   ./scripts/release.sh 0.5.0-rc.1   # → version: 0.5.0-rc.1+50001, tag v0.5.0-rc.1
+#
+# Version code formula (matches CI in .github/actions/android-build/action.yml):
+#   BASE_CODE = MAJOR * 1000000 + MINOR * 10000 + PATCH * 100
+#   RC releases: BASE_CODE + RC_NUM
+#   Final releases: BASE_CODE + 90
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+VERSION="$1"
+
+if [[ -z "$VERSION" ]]; then
+    echo "Usage: $0 <version>"
+    echo ""
+    echo "Examples:"
+    echo "  $0 0.5.0        # Final release"
+    echo "  $0 0.5.0-rc.1   # Release candidate"
+    exit 1
+fi
+
+# Extract base version (strip -rc.N, -alpha, etc.)
+BASE_VERSION=$(echo "$VERSION" | sed 's/-rc\..*//' | sed 's/-alpha.*//')
+MAJOR=$(echo "$BASE_VERSION" | cut -d. -f1)
+MINOR=$(echo "$BASE_VERSION" | cut -d. -f2)
+PATCH=$(echo "$BASE_VERSION" | cut -d. -f3)
+
+if [[ -z "$MAJOR" || -z "$MINOR" || -z "$PATCH" ]]; then
+    echo "Error: Invalid version format '$VERSION'. Expected X.Y.Z or X.Y.Z-rc.N"
+    exit 1
+fi
+
+# Calculate version code
+BASE_CODE=$((MAJOR * 1000000 + MINOR * 10000 + PATCH * 100))
+
+if [[ "$VERSION" == *"-rc."* ]]; then
+    RC_NUM=$(echo "$VERSION" | sed 's/.*-rc\.//')
+    VERSION_CODE=$((BASE_CODE + RC_NUM))
+else
+    # Final release gets +90 to be above all RCs (room for 89 RCs)
+    VERSION_CODE=$((BASE_CODE + 90))
+fi
+
+TAG="v$VERSION"
+
+echo "Release: $VERSION"
+echo "Version code: $VERSION_CODE"
+echo "Tag: $TAG"
+echo ""
+
+# Check for uncommitted changes
+if ! git -C "$PROJECT_ROOT" diff --quiet || ! git -C "$PROJECT_ROOT" diff --cached --quiet; then
+    echo "Error: You have uncommitted changes. Please commit or stash them first."
+    exit 1
+fi
+
+# Check if tag already exists
+if git -C "$PROJECT_ROOT" rev-parse "$TAG" >/dev/null 2>&1; then
+    echo "Error: Tag '$TAG' already exists."
+    exit 1
+fi
+
+# Update pubspec.yaml
+sed -i "s/^version: .*/version: $VERSION+$VERSION_CODE/" "$PROJECT_ROOT/pubspec.yaml"
+echo "Updated pubspec.yaml → version: $VERSION+$VERSION_CODE"
+
+# Update Cargo.toml (without versionCode)
+sed -i "s/^version = \".*\"/version = \"$VERSION\"/" "$PROJECT_ROOT/rust/ecashapp/Cargo.toml"
+echo "Updated Cargo.toml → version: $VERSION"
+
+# Add appstream release entry
+APPSTREAM_FILE="$PROJECT_ROOT/linux/appstream/org.fedimint.app.appdata.xml"
+RELEASE_DATE=$(date +%Y-%m-%d)
+RELEASE_ENTRY="    <release version=\"$VERSION\" date=\"$RELEASE_DATE\" />"
+sed -i "s|  <releases>|  <releases>\n$RELEASE_ENTRY|" "$APPSTREAM_FILE"
+echo "Updated appstream → release $VERSION ($RELEASE_DATE)"
+
+# Commit and tag
+git -C "$PROJECT_ROOT" add pubspec.yaml rust/ecashapp/Cargo.toml "$APPSTREAM_FILE"
+git -C "$PROJECT_ROOT" commit -m "chore: bump version to $TAG"
+git -C "$PROJECT_ROOT" tag "$TAG"
+
+echo ""
+echo "Done! Created commit and tag '$TAG'."
+echo ""
+echo "To push:"
+echo "  git push origin master && git push origin $TAG"


### PR DESCRIPTION
Refactors the version code calculation and adds a `release.sh` script so that the releases branch will have the version code in `pubspec.yml`

My preference would be to backport this to the `v0.5` branch after the `v0.5.0` release and test with the `v0.5.1` release candidates.