### PR TITLE
fix: run flutter pub get for fresh clones

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -58,6 +58,11 @@
               if [ -d .git ]; then
                 ln -sf "$PWD/scripts/git-hooks/pre-commit.sh" .git/hooks/pre-commit
               fi
+              # Ensure flutter deps are resolved (needed for dart format in pre-commit hook)
+              if [ ! -f .dart_tool/package_config.json ]; then
+                echo "Running flutter pub get (first-time setup)..."
+                flutter pub get > /dev/null 2>&1
+              fi
 	    '';
           });
         };


### PR DESCRIPTION
The pre-commit hook fails on a fresh clone, which we can resolve by conditionally running `flutter pub get` as a shell hook.

```
Warning: Package resolution error when reading "analysis_options.yaml" file:
Failed to resolve package URI "package:flutter_lints/flutter.yaml" in include.
Warning: Package resolution error when reading "analysis_options.yaml" file:
Failed to resolve package URI "package:flutter_lints/flutter.yaml" in include.
Warning: Package resolution error when reading "analysis_options.yaml" file:
Failed to resolve package URI "package:flutter_lints/flutter.yaml" in include.
Warning: Package resolution error when reading "analysis_options.yaml" file:
Failed to resolve package URI "package:flutter_lints/flutter.yaml" in include.
Warning: Package resolution error when reading "analysis_options.yaml" file:
Failed to resolve package URI "package:flutter_lints/flutter.yaml" in include.
Warning: Package resolution error when reading "analysis_options.yaml" file:
Failed to resolve package URI "package:flutter_lints/flutter.yaml" in include.

✖  Dart files aren’t formatted!
Please run:

    dart format lib/**/*.dart

and then try committing again.
```