### PR TITLE
[Backport v0.5] chore: add appstream release entry for v0.5.0

### DIFF
--- a/linux/appstream/org.fedimint.app.appdata.xml
+++ b/linux/appstream/org.fedimint.app.appdata.xml
@@ -53,6 +53,6 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
-    <release version="0.5.0-alpha" date="2026-01-24" />
+    <release version="0.5.0" date="2026-02-12" />
   </releases>
 </component>


### PR DESCRIPTION
Followup now that we released v0.5.0