### PR TITLE
refactor: new scanner, proguard rules, claude update to verify build

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -163,6 +163,15 @@ Key concepts:
 
 No test commands are currently defined in the justfile. Manual testing is done by running the app.
 
+### Build Verification
+
+**IMPORTANT:** After making any code changes, always verify the Android build by running:
+```bash
+just build-debug-apk
+```
+
+This ensures changes don't break the Android build, which uses a Docker-based reproducible build system.
+
 ## Code Generation
 
 The project uses multiple code generation tools:

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -10,7 +10,9 @@ plugins {
 val keystorePropertiesFile = rootProject.file("key.properties")
 val keystoreProperties = Properties()
 
-if (keystorePropertiesFile.exists()) {
+val hasSigningConfig = keystorePropertiesFile.exists()
+
+if (hasSigningConfig) {
     keystoreProperties.load(keystorePropertiesFile.inputStream())
 }
 
@@ -40,21 +42,31 @@ android {
         }
     }
 
-    signingConfigs {
-        create("release") {
-            storeFile = keystoreProperties["storeFile"]?.let { file(it as String) }
-            storePassword = keystoreProperties["storePassword"] as String?
-            keyAlias = keystoreProperties["keyAlias"] as String?
-            keyPassword = keystoreProperties["keyPassword"] as String?
-            storeType = "pkcs12"
+    // Only configure signing if key.properties exists
+    // F-Droid builds unsigned APKs and signs them with their own key
+    if (hasSigningConfig) {
+        signingConfigs {
+            create("release") {
+                storeFile = keystoreProperties["storeFile"]?.let { file(it as String) }
+                storePassword = keystoreProperties["storePassword"] as String?
+                keyAlias = keystoreProperties["keyAlias"] as String?
+                keyPassword = keystoreProperties["keyPassword"] as String?
+                storeType = "pkcs12"
+            }
         }
     }
 
     buildTypes {
         release {
-            signingConfig = signingConfigs.getByName("release")
-            isMinifyEnabled = false
-            isShrinkResources = false
+            if (hasSigningConfig) {
+                signingConfig = signingConfigs.getByName("release")
+            }
+            isMinifyEnabled = true
+            isShrinkResources = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
         }
     }
 }

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,11 @@
+# Proguard rules for F-Droid compatibility
+# 
+# IMPORTANT: Do NOT add -keep rules for io.flutter.** classes.
+# This allows R8 to tree-shake unused Flutter embedding classes
+# that reference Google Play Core (PlayStoreDeferredComponentManager,
+# FlutterPlayStoreSplitApplication), which are not needed for this app.
+#
+# See: https://gitlab.com/fdroid/fdroiddata/-/issues/2949
+
+# Suppress warnings about Play Core classes (they will be stripped by R8)
+-dontwarn com.google.android.play.core.**

--- a/justfile
+++ b/justfile
@@ -15,6 +15,9 @@ build-linux:
 build-debug-apk:
   $ROOT/docker/build-apk.sh debug
 
+build-release-apk:
+  $ROOT/docker/build-apk.sh release
+
 build-appimage:
   $ROOT/docker/build-appimage.sh
 
@@ -27,3 +30,15 @@ run: build-linux
 
 test:
   flutter test
+
+# Scan the latest APK for F-Droid compatibility (checks for Google Play Services dependencies)
+scan-apk:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  APK=$(ls -t build/app/outputs/flutter-apk/ecashapp-*.apk 2>/dev/null | head -1)
+  if [ -z "$APK" ]; then
+    echo "No APK found. Run 'just build-debug-apk' first."
+    exit 1
+  fi
+  echo "Scanning: $APK"
+  fdroid scanner -v --exit-code "$APK"

--- a/lib/scan.dart
+++ b/lib/scan.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:ecashapp/app.dart';
 import 'package:ecashapp/fed_preview.dart';
@@ -16,7 +17,8 @@ import 'package:collection/collection.dart';
 import 'package:crypto/crypto.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:mobile_scanner/mobile_scanner.dart';
+import 'package:permission_handler/permission_handler.dart';
+import 'package:qr_code_scanner_plus/qr_code_scanner_plus.dart';
 
 class ScanQRPage extends StatefulWidget {
   final FederationSelector? selectedFed;
@@ -39,11 +41,60 @@ class ScanQRPage extends StatefulWidget {
 class _ScanQRPageState extends State<ScanQRPage> {
   bool _scanned = false;
   bool _isPasting = false;
+  bool _permissionDenied = false;
   _QrLoopSession? _currentSession;
+
+  final GlobalKey qrKey = GlobalKey(debugLabel: 'QR');
+  QRViewController? _qrController;
 
   final List<_FountainFramePending> _pendingFountains = [];
   final Set<String> _exploredFountains = {};
   static const int FOUNTAIN_V1_CONST = 100;
+
+  @override
+  void initState() {
+    super.initState();
+    _requestCameraPermission();
+  }
+
+  Future<void> _requestCameraPermission() async {
+    // Skip permission check on desktop platforms where it's not supported
+    if (Platform.isLinux || Platform.isMacOS || Platform.isWindows) {
+      return;
+    }
+    final status = await Permission.camera.status;
+    if (!status.isGranted) {
+      final result = await Permission.camera.request();
+      if (!result.isGranted) {
+        setState(() => _permissionDenied = true);
+      }
+    }
+  }
+
+  // Required for hot reload to work properly with qr_code_scanner_plus
+  @override
+  void reassemble() {
+    super.reassemble();
+    if (Platform.isAndroid) {
+      _qrController?.pauseCamera();
+    }
+    _qrController?.resumeCamera();
+  }
+
+  @override
+  void dispose() {
+    _qrController?.dispose();
+    super.dispose();
+  }
+
+  void _onQRViewCreated(QRViewController controller) {
+    _qrController = controller;
+    controller.scannedDataStream.listen((scanData) {
+      if (scanData.code != null && scanData.code!.isNotEmpty) {
+        _handleQrLoopChunk(scanData.code!);
+      }
+    });
+  }
 
   void _handleQrLoopChunk(String base64Str) async {
     if (_scanned) return;
@@ -496,13 +547,48 @@ class _ScanQRPageState extends State<ScanQRPage> {
         body: Stack(
           children: [
             Positioned.fill(
-              child: MobileScanner(
-                onDetect: (capture) {
-                  final barcode = capture.barcodes.first;
-                  final String? code = barcode.rawValue;
-                  if (code != null) _handleQrLoopChunk(code);
-                },
-              ),
+              child:
+                  (_permissionDenied || Platform.isLinux)
+                      ? Center(
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            const Icon(
+                              Icons.camera_alt_outlined,
+                              size: 64,
+                              color: Colors.grey,
+                            ),
+                            const SizedBox(height: 16),
+                            Text(
+                              Platform.isLinux
+                                  ? 'Camera scanning is not supported on Linux.\nUse the "Paste from Clipboard" button below.'
+                                  : 'Camera permission is required to scan QR codes',
+                              textAlign: TextAlign.center,
+                              style: const TextStyle(color: Colors.grey),
+                            ),
+                            if (_permissionDenied && !Platform.isLinux) ...[
+                              const SizedBox(height: 16),
+                              ElevatedButton(
+                                onPressed: () async {
+                                  await openAppSettings();
+                                },
+                                child: const Text('Open Settings'),
+                              ),
+                            ],
+                          ],
+                        ),
+                      )
+                      : QRView(
+                        key: qrKey,
+                        onQRViewCreated: _onQRViewCreated,
+                        overlay: QrScannerOverlayShape(
+                          borderColor: Theme.of(context).colorScheme.primary,
+                          borderRadius: 10,
+                          borderLength: 30,
+                          borderWidth: 10,
+                          cutOutSize: 280,
+                        ),
+                      ),
             ),
             if (_progress != null)
               Align(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -520,14 +520,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
-  mobile_scanner:
-    dependency: "direct main"
-    description:
-      name: mobile_scanner
-      sha256: "54005bdea7052d792d35b4fef0f84ec5ddc3a844b250ecd48dc192fb9b4ebc95"
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.0.1"
   mocktail:
     dependency: "direct dev"
     description:
@@ -752,6 +744,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
+  qr_code_scanner_plus:
+    dependency: "direct main"
+    description:
+      name: qr_code_scanner_plus
+      sha256: dae0596b2763c2fd0294f5cfddb1d3a21577ae4dc7fc1449eb5aafc957872f61
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   qr_flutter:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_rust_bridge: 2.9.0
-  mobile_scanner: ^7.0.1
+  qr_code_scanner_plus: ^2.1.1
   qr_flutter: ^4.1.0
   intl: ^0.18.1
   numpad_layout: ^0.0.3


### PR DESCRIPTION
This PR:

 - Replaces `mobile_scanner` with `qr_code_scanner_plus` so that it doesn't bring in Google dependencies
 - Adds `just scan-apk` to test for Google dependencies
 - Updates `CLAUDE.md` so that it knows how to verify the Android build
 - Adjusts the signing config so that we can build unsigned release builds to testing the scanning (debug builds will fail the scanning)