### PR TITLE
chore: change proguard rules

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,11 +1,31 @@
 # Proguard rules for F-Droid compatibility
-# 
-# IMPORTANT: Do NOT add -keep rules for io.flutter.** classes.
-# This allows R8 to tree-shake unused Flutter embedding classes
-# that reference Google Play Core (PlayStoreDeferredComponentManager,
-# FlutterPlayStoreSplitApplication), which are not needed for this app.
+#
+# We selectively keep Flutter plugin/util/view classes (needed for platform
+# channels and networking) but do NOT keep io.flutter.app.** — this allows R8
+# to strip PlayStoreDeferredComponentManager, FlutterPlayStoreSplitApplication,
+# and other Google Play Core embedding classes.
 #
 # See: https://gitlab.com/fdroid/fdroiddata/-/issues/2949
 
 # Suppress warnings about Play Core classes (they will be stripped by R8)
 -dontwarn com.google.android.play.core.**
+
+# Keep Flutter plugin classes (needed for platform channels, including networking)
+-keep class io.flutter.plugins.** { *; }
+-keep class io.flutter.plugin.** { *; }
+-keep class io.flutter.util.** { *; }
+-keep class io.flutter.view.** { *; }
+
+# Keep OkHttp (Android's HTTP stack, used via reflection)
+-keep class okhttp3.** { *; }
+-keep class okio.** { *; }
+-dontwarn okhttp3.**
+-dontwarn okio.**
+
+# Keep SSL/TLS classes needed for HTTPS connections
+-keep class javax.net.ssl.** { *; }
+-dontwarn javax.net.ssl.**
+
+# Keep Cronet if used by Flutter
+-keep class org.chromium.net.** { *; }
+-dontwarn org.chromium.net.**


### PR DESCRIPTION
Adding INTERNET permission did not work, so I suspect the proguard rules are stripping out classes that are used via reflection that is causing the networking issue.