### PR TITLE
fix: Sort by vetted, check internal payment, and dedup version when listing gateways

### DIFF
--- a/lib/frb_generated.dart
+++ b/lib/frb_generated.dart
@@ -11048,8 +11048,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   FedimintGateway dco_decode_fedimint_gateway(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 8)
-      throw Exception('unexpected arr length: expect 8 but see ${arr.length}');
+    if (arr.length != 9)
+      throw Exception('unexpected arr length: expect 9 but see ${arr.length}');
     return FedimintGateway(
       endpoint: dco_decode_String(arr[0]),
       baseRoutingFee: dco_decode_u_64(arr[1]),
@@ -11059,6 +11059,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       lightningAlias: dco_decode_opt_String(arr[5]),
       lightningNode: dco_decode_opt_String(arr[6]),
       isLnv2: dco_decode_bool(arr[7]),
+      isVettted: dco_decode_bool(arr[8]),
     );
   }
 
@@ -13227,6 +13228,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_lightningAlias = sse_decode_opt_String(deserializer);
     var var_lightningNode = sse_decode_opt_String(deserializer);
     var var_isLnv2 = sse_decode_bool(deserializer);
+    var var_isVettted = sse_decode_bool(deserializer);
     return FedimintGateway(
       endpoint: var_endpoint,
       baseRoutingFee: var_baseRoutingFee,
@@ -13236,6 +13238,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       lightningAlias: var_lightningAlias,
       lightningNode: var_lightningNode,
       isLnv2: var_isLnv2,
+      isVettted: var_isVettted,
     );
   }
 
@@ -15651,6 +15654,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_opt_String(self.lightningAlias, serializer);
     sse_encode_opt_String(self.lightningNode, serializer);
     sse_encode_bool(self.isLnv2, serializer);
+    sse_encode_bool(self.isVettted, serializer);
   }
 
   @protected

--- a/lib/multimint.dart
+++ b/lib/multimint.dart
@@ -447,6 +447,7 @@ class FedimintGateway {
   final String? lightningAlias;
   final String? lightningNode;
   final bool isLnv2;
+  final bool isVettted;
 
   const FedimintGateway({
     required this.endpoint,
@@ -457,6 +458,7 @@ class FedimintGateway {
     this.lightningAlias,
     this.lightningNode,
     required this.isLnv2,
+    required this.isVettted,
   });
 
   @override
@@ -468,7 +470,8 @@ class FedimintGateway {
       ppmTransactionFee.hashCode ^
       lightningAlias.hashCode ^
       lightningNode.hashCode ^
-      isLnv2.hashCode;
+      isLnv2.hashCode ^
+      isVettted.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -482,7 +485,8 @@ class FedimintGateway {
           ppmTransactionFee == other.ppmTransactionFee &&
           lightningAlias == other.lightningAlias &&
           lightningNode == other.lightningNode &&
-          isLnv2 == other.isLnv2;
+          isLnv2 == other.isLnv2 &&
+          isVettted == other.isVettted;
 }
 
 class GatewayPaymentPreview {

--- a/rust/ecashapp/src/frb_generated.rs
+++ b/rust/ecashapp/src/frb_generated.rs
@@ -13208,6 +13208,7 @@ impl SseDecode for crate::multimint::FedimintGateway {
         let mut var_lightningAlias = <Option<String>>::sse_decode(deserializer);
         let mut var_lightningNode = <Option<String>>::sse_decode(deserializer);
         let mut var_isLnv2 = <bool>::sse_decode(deserializer);
+        let mut var_isVettted = <bool>::sse_decode(deserializer);
         return crate::multimint::FedimintGateway {
             endpoint: var_endpoint,
             base_routing_fee: var_baseRoutingFee,
@@ -13217,6 +13218,7 @@ impl SseDecode for crate::multimint::FedimintGateway {
             lightning_alias: var_lightningAlias,
             lightning_node: var_lightningNode,
             is_lnv2: var_isLnv2,
+            is_vettted: var_isVettted,
         };
     }
 }
@@ -15697,6 +15699,7 @@ impl flutter_rust_bridge::IntoDart for crate::multimint::FedimintGateway {
             self.lightning_alias.into_into_dart().into_dart(),
             self.lightning_node.into_into_dart().into_dart(),
             self.is_lnv2.into_into_dart().into_dart(),
+            self.is_vettted.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -16923,6 +16926,7 @@ impl SseEncode for crate::multimint::FedimintGateway {
         <Option<String>>::sse_encode(self.lightning_alias, serializer);
         <Option<String>>::sse_encode(self.lightning_node, serializer);
         <bool>::sse_encode(self.is_lnv2, serializer);
+        <bool>::sse_encode(self.is_vettted, serializer);
     }
 }
 

--- a/rust/ecashapp/src/multimint.rs
+++ b/rust/ecashapp/src/multimint.rs
@@ -1899,7 +1899,7 @@ impl Multimint {
         amount: Amount,
         bolt11: &Bolt11Invoice,
     ) -> anyhow::Result<Vec<GatewayPaymentPreview>> {
-        let mut previews: BTreeMap<SafeUrl, GatewayPaymentPreview> = BTreeMap::new();
+        let mut previews: BTreeMap<String, GatewayPaymentPreview> = BTreeMap::new();
 
         let client = self
             .clients
@@ -1937,8 +1937,9 @@ impl Multimint {
                         is_lnv2: false,
                         is_vettted: g.vetted,
                     };
+                    let url = info.api.host_str().expect("No host in URL").to_string();
                     (
-                        info.api,
+                        url,
                         GatewayPaymentPreview {
                             gateway: gw,
                             amount_with_fees,
@@ -1963,7 +1964,8 @@ impl Multimint {
             if let Ok(lnv2_urls) = lnv2_gateways {
                 let routing_infos =
                     futures_util::future::join_all(lnv2_urls.iter().map(|url| async {
-                        let routing_info = lnv2.routing_info(url).await;
+                        let routing_info =
+                            timeout(Duration::from_secs(5), lnv2.routing_info(url)).await;
                         (url.clone(), routing_info)
                     }))
                     .await;
@@ -1971,7 +1973,7 @@ impl Multimint {
                 let lnv2_gw_infos = routing_infos
                     .iter()
                     .filter_map(|(url, info)| {
-                        if let Ok(Some(info)) = info {
+                        if let Ok(Ok(Some(info))) = info {
                             let send_fee =
                                 if bolt11.get_payee_pub_key() == info.lightning_public_key {
                                     info.send_fee_minimum
@@ -1991,8 +1993,9 @@ impl Multimint {
                                 is_lnv2: true,
                                 is_vettted: true, // all LNv2 gateways are vetted
                             };
+                            let url = url.host_str().expect("No host in URL").to_string();
                             Some((
-                                url.clone(),
+                                url,
                                 GatewayPaymentPreview {
                                     gateway: gw,
                                     amount_with_fees,
@@ -2014,7 +2017,7 @@ impl Multimint {
             b.gateway
                 .is_lnv2
                 .cmp(&a.gateway.is_lnv2)
-                .then(a.gateway.is_vettted.cmp(&b.gateway.is_vettted))
+                .then(b.gateway.is_vettted.cmp(&a.gateway.is_vettted))
                 .then(a.amount_with_fees.cmp(&b.amount_with_fees))
         });
 
@@ -3517,7 +3520,8 @@ impl Multimint {
                         is_lnv2: false,
                         is_vettted: g.vetted,
                     };
-                    (info.api, gw)
+                    let url = info.api.host_str().expect("No host in URL").to_string();
+                    (url, gw)
                 })
                 .collect::<BTreeMap<_, _>>();
 
@@ -3529,7 +3533,8 @@ impl Multimint {
             if let Ok(lnv2_urls) = lnv2_gateways {
                 let routing_infos =
                     futures_util::future::join_all(lnv2_urls.iter().map(|url| async {
-                        let routing_info = lnv2.routing_info(url).await;
+                        let routing_info =
+                            timeout(Duration::from_secs(15), lnv2.routing_info(url)).await;
                         (url.clone(), routing_info)
                     }))
                     .await;
@@ -3537,7 +3542,7 @@ impl Multimint {
                 let lnv2_gw_infos = routing_infos
                     .iter()
                     .filter_map(|(url, info)| {
-                        if let Ok(Some(info)) = info {
+                        if let Ok(Ok(Some(info))) = info {
                             let gw = FedimintGateway {
                                 endpoint: url.to_string(),
                                 base_routing_fee: info.send_fee_default.base.msats,
@@ -3549,7 +3554,8 @@ impl Multimint {
                                 is_lnv2: true,
                                 is_vettted: true, // all LNv2 gateways are vetted
                             };
-                            Some((url.clone(), gw))
+                            let url = url.host_str().expect("No host in URL").to_string();
+                            Some((url, gw))
                         } else {
                             None
                         }
@@ -3565,7 +3571,7 @@ impl Multimint {
         gateway_previews.sort_by(|a, b| {
             b.is_lnv2
                 .cmp(&a.is_lnv2)
-                .then(a.is_vettted.cmp(&b.is_vettted))
+                .then(b.is_vettted.cmp(&a.is_vettted))
         });
 
         Ok(gateway_previews)


### PR DESCRIPTION
There were a few bugs when listing gateways in both the main screen and the payment modal before making a payment. The logic is very similar but unfortunately somewhat difficult to unify right now.

For now, this PR fixes the bugs by sorting by if the gateway is vetted, getting the correct fee depending on if the payment is internal or not, and de-duplicating gateway URLs based on host.