### PR TITLE
chore: Detect architecture in build-apk script

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -69,13 +69,18 @@ RUN yes | sdkmanager --licenses \
         "build-tools;35.0.0" \
         "cmake;3.22.1"
 
-# Install appimagetool for Linux AppImage builds (extract since FUSE unavailable in containers)
-RUN wget -q https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage -O /tmp/appimagetool.AppImage \
-    && chmod +x /tmp/appimagetool.AppImage \
-    && cd /tmp && ./appimagetool.AppImage --appimage-extract \
-    && mv /tmp/squashfs-root /opt/appimagetool \
-    && ln -s /opt/appimagetool/AppRun /usr/local/bin/appimagetool \
-    && rm /tmp/appimagetool.AppImage
+# Install appimagetool for Linux AppImage builds (only needed by
+# build-appimage.sh; APK builds skip this to avoid the AppImage runtime
+# self-extract step, which fails under amd64 emulation on Apple Silicon).
+ARG INSTALL_APPIMAGETOOL=false
+RUN if [ "$INSTALL_APPIMAGETOOL" = "true" ]; then \
+        wget -q https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage -O /tmp/appimagetool.AppImage \
+        && chmod +x /tmp/appimagetool.AppImage \
+        && cd /tmp && ./appimagetool.AppImage --appimage-extract \
+        && mv /tmp/squashfs-root /opt/appimagetool \
+        && ln -s /opt/appimagetool/AppRun /usr/local/bin/appimagetool \
+        && rm /tmp/appimagetool.AppImage ; \
+    fi
 
 WORKDIR /workspace
 

--- a/docker/build-apk.sh
+++ b/docker/build-apk.sh
@@ -57,9 +57,22 @@ mkdir -p "$PROJECT_ROOT/.docker-cache/android"
 # Build the Docker image if it doesn't exist or if forced
 IMAGE_NAME="ecash-app-builder"
 
+# The NDK toolchain installed in the image is linux-x86_64, so the container
+# must always be linux/amd64. On amd64 hosts that's the natural default; on
+# arm64 hosts (Apple Silicon, arm64 Linux) we force amd64 emulation via
+# Rosetta/qemu. We only pass --platform when needed to avoid BuildKit's
+# FromPlatformFlagConstDisallowed warning and any unnecessary platform
+# mismatch noise on amd64 hosts.
+PLATFORM_ARGS=()
+if [[ "$(uname -m)" != "x86_64" ]]; then
+    PLATFORM_ARGS=(--platform=linux/amd64)
+    echo "Host arch $(uname -m) detected; forcing linux/amd64 emulation."
+    echo ""
+fi
+
 if ! docker image inspect $IMAGE_NAME &> /dev/null || [[ "${REBUILD_IMAGE}" == "1" ]]; then
     echo "Building Docker image..."
-    docker build --build-arg FLUTTER_VERSION=$(cat "$PROJECT_ROOT/.flutter-version") -t $IMAGE_NAME "$SCRIPT_DIR"
+    docker build "${PLATFORM_ARGS[@]}" --build-arg FLUTTER_VERSION=$(cat "$PROJECT_ROOT/.flutter-version") -t $IMAGE_NAME "$SCRIPT_DIR"
     echo ""
 else
     echo "Using existing Docker image: $IMAGE_NAME"
@@ -73,6 +86,7 @@ fi
 
 echo "Starting build in Docker container..."
 docker run --rm \
+    "${PLATFORM_ARGS[@]}" \
     --user "$(id -u):$(id -g)" \
     -v "$PROJECT_ROOT:/workspace" \
     -v "$PROJECT_ROOT/.docker-cache/gradle:/gradle-cache" \

--- a/docker/build-appimage.sh
+++ b/docker/build-appimage.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-IMAGE_NAME="ecash-app-builder"
+IMAGE_NAME="ecash-app-appimage-builder"
 
 # Show build configuration
 echo "Build configuration:"
@@ -20,7 +20,10 @@ echo ""
 # Build Docker image if needed
 if ! docker image inspect $IMAGE_NAME &> /dev/null || [[ "${REBUILD_IMAGE:-}" == "1" ]]; then
     echo "Building Docker image..."
-    docker build --build-arg FLUTTER_VERSION=$(cat "$PROJECT_ROOT/.flutter-version") -t $IMAGE_NAME "$SCRIPT_DIR"
+    docker build \
+        --build-arg FLUTTER_VERSION=$(cat "$PROJECT_ROOT/.flutter-version") \
+        --build-arg INSTALL_APPIMAGETOOL=true \
+        -t $IMAGE_NAME "$SCRIPT_DIR"
 fi
 
 # Create cache directories (owned by current user)


### PR DESCRIPTION
Allows for building apk on Apple Silicon and arm linux machines