### PR TITLE
chore: version to v0.9.0-alpha

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ecashapp
 description: "A Fedimint Wallet"
 publish_to: 'none'
-version: 0.10.0-alpha
+version: 0.9.0-alpha
 
 environment:
   sdk: ^3.7.2

--- a/rust/ecashapp/Cargo.lock
+++ b/rust/ecashapp/Cargo.lock
@@ -1281,7 +1281,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecashapp"
-version = "0.10.0-alpha"
+version = "0.9.0-alpha"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/rust/ecashapp/Cargo.toml
+++ b/rust/ecashapp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecashapp"
-version = "0.10.0-alpha"
+version = "0.9.0-alpha"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
Accidentally bumped the version too high. Setting to `v0.9.0-alpha`