### PR TITLE
fix: apply macos entitlements to release build

### DIFF
--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -46,6 +46,7 @@ APP_PATH="build/macos/Build/Products/Release/ecashapp.app"
 if [ -n "$MACOS_SIGN_IDENTITY" ]; then
   echo "Signing app with: $MACOS_SIGN_IDENTITY"
   codesign --deep --force --options runtime \
+    --entitlements macos/Runner/Release.entitlements \
     --sign "$MACOS_SIGN_IDENTITY" "$APP_PATH"
 fi
 


### PR DESCRIPTION
This should make the app properly sandboxed. Difficult for me to test without a macos, we can do more testing on a release candidate.