### PR TITLE
fix: Release replaces version string correctly

### DIFF
--- a/.github/actions/android-build/action.yml
+++ b/.github/actions/android-build/action.yml
@@ -130,9 +130,13 @@ runs:
         sed -i 's/namespace = ".*"/namespace = "org.fedimint.app"/' android/app/build.gradle.kts
         sed -i 's/applicationId = ".*"/applicationId = "org.fedimint.app"/' android/app/build.gradle.kts
 
-        # Update package in MainActivity.kt
+        # Update the package in EVERY Kotlin source (MainActivity, EcashHceService, …)
+        # so they all share the same package as the namespace. Rewriting only one file
+        # orphans the others in org.fedimint.app.master and the release build fails with
+        # "Unresolved reference".
         CURRENT_PACKAGE=$(grep '^package ' android/app/src/main/kotlin/app/ecash/MainActivity.kt | sed 's/package //')
-        sed -i "s/package ${CURRENT_PACKAGE}/package org.fedimint.app/" android/app/src/main/kotlin/app/ecash/MainActivity.kt
+        find android/app/src/main/kotlin -name '*.kt' -print0 \
+          | xargs -0 sed -i "s/^package ${CURRENT_PACKAGE}\$/package org.fedimint.app/"
 
         # Update APPLICATION_ID in Linux CMakeLists.txt
         sed -i 's/set(APPLICATION_ID ".*")/set(APPLICATION_ID "org.fedimint.app")/' linux/CMakeLists.txt

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -89,10 +89,18 @@ echo "Updating Cargo.lock..."
 cargo check --manifest-path "$PROJECT_ROOT/rust/ecashapp/Cargo.toml" --target-dir "$PROJECT_ROOT/rust/ecashapp/target" 2>/dev/null || true
 echo "Updated Cargo.lock"
 
-# Update Android package ID to production (org.fedimint.app)
+# Update Android package ID to production (org.fedimint.app) in the Gradle config
+# AND every Kotlin source. The source `package` must move in lockstep with the
+# namespace: if MainActivity.kt is rewritten but a sibling like EcashHceService.kt
+# is left at org.fedimint.app.master, they land in different packages and the
+# release build fails with "Unresolved reference". This also keeps the tagged
+# commit fully production-consistent for F-Droid, which builds from the tag
+# without the CI package-id rewrite.
 GRADLE_FILE="$PROJECT_ROOT/android/app/build.gradle.kts"
 sed -i 's/org\.fedimint\.app\.master/org.fedimint.app/g' "$GRADLE_FILE"
-echo "Updated build.gradle.kts → applicationId: org.fedimint.app"
+find "$PROJECT_ROOT/android/app/src/main/kotlin" -name '*.kt' -print0 \
+    | xargs -0 sed -i 's/org\.fedimint\.app\.master/org.fedimint.app/g'
+echo "Updated build.gradle.kts + Kotlin sources → package: org.fedimint.app"
 
 # For final releases only: update appstream and create changelog
 APPSTREAM_FILE=""
@@ -145,7 +153,7 @@ EOF
 fi
 
 # Commit and tag
-git -C "$PROJECT_ROOT" add pubspec.yaml rust/ecashapp/Cargo.toml rust/ecashapp/Cargo.lock android/app/build.gradle.kts
+git -C "$PROJECT_ROOT" add pubspec.yaml rust/ecashapp/Cargo.toml rust/ecashapp/Cargo.lock android/app/build.gradle.kts android/app/src/main/kotlin
 if [[ -n "$APPSTREAM_FILE" && -f "$APPSTREAM_FILE" ]]; then
     git -C "$PROJECT_ROOT" add "$APPSTREAM_FILE"
 fi


### PR DESCRIPTION
`v0.9.0-rc.0` is failing because we added a new kotlin file but aren't find-replacing the version string in it: https://github.com/fedimint/ecash-app/actions/runs/28386944100/job/84103921557

PR updates our build scripts and CI to do that replacement.