### PR TITLE
fix: display loading screen before federation preview

### DIFF
--- a/lib/discover.dart
+++ b/lib/discover.dart
@@ -4,7 +4,6 @@ import 'package:ecashapp/lib.dart';
 import 'package:ecashapp/multimint.dart';
 import 'package:ecashapp/nostr.dart';
 import 'package:ecashapp/toast.dart';
-import 'package:ecashapp/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:shimmer/shimmer.dart';
@@ -20,11 +19,11 @@ class Discover extends StatefulWidget {
 
 class _Discover extends State<Discover> with SingleTickerProviderStateMixin {
   late Future<List<PublicFederation>> _futureFeds;
-  PublicFederation? _gettingMetadata;
 
   final TextEditingController _inviteCodeController = TextEditingController();
   bool _isInviteCodeValid = false;
-  bool _isLoadingInvitePreview = false;
+  // Guards against pushing the preview route twice while one is already opening.
+  bool _isOpeningPreview = false;
 
   @override
   void initState() {
@@ -48,66 +47,47 @@ class _Discover extends State<Discover> with SingleTickerProviderStateMixin {
     }
   }
 
-  Future<void> _onPreviewPressed(String inviteCode) async {
-    final overlay = OverlayEntry(
-      builder:
-          (_) => Container(
-            color: Colors.black54,
-            child: const Center(child: CircularProgressIndicator()),
-          ),
+  Future<void> _onPreviewPressed(
+    String inviteCode, {
+    String? previewName,
+  }) async {
+    if (_isOpeningPreview) return;
+    setState(() => _isOpeningPreview = true);
+
+    // Open the preview screen immediately. It downloads the federation config
+    // itself and shows a loading/error state, so the user always has a back
+    // button instead of being stuck behind a blocking spinner.
+    final fed = await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder:
+            (_) => FederationInfoScreen(
+              inviteCode: inviteCode,
+              previewName: previewName,
+              joinable: true,
+              onLeaveFederation: () {},
+            ),
+      ),
     );
-    try {
-      setState(() {
-        _gettingMetadata = null;
-        _isLoadingInvitePreview = false;
-      });
 
-      Overlay.of(context).insert(overlay);
-      final meta = await getFederationMeta(inviteCode: inviteCode);
-      overlay.remove();
-      if (!mounted) return;
-      final fed = await Navigator.push(
-        context,
-        MaterialPageRoute(
-          builder:
-              (_) => FederationInfoScreen(
-                fed: meta.selector,
-                inviteCode: inviteCode,
-                welcomeMessage: meta.welcome,
-                imageUrl: meta.picture,
-                joinable: true,
-                onLeaveFederation: () {},
-              ),
-        ),
-      );
+    if (mounted) setState(() => _isOpeningPreview = false);
 
-      if (fed != null) {
-        final name = fed.$1.federationName;
-        widget.onJoin(fed.$1, fed.$2);
+    if (fed != null) {
+      final name = fed.$1.federationName;
+      widget.onJoin(fed.$1, fed.$2);
 
-        // If we're in a pushed route (showAppBar is true), pop back to main screen
-        // so the user can see the newly joined federation
-        if (widget.showAppBar && mounted) {
-          Navigator.popUntil(context, (route) => route.isFirst);
-        }
-
-        ToastService().show(
-          message: context.l10n.joinedFederation(name),
-          duration: const Duration(seconds: 5),
-          onTap: () {},
-          icon: const Icon(Icons.info),
-        );
+      // If we're in a pushed route (showAppBar is true), pop back to main screen
+      // so the user can see the newly joined federation
+      if (widget.showAppBar && mounted) {
+        Navigator.popUntil(context, (route) => route.isFirst);
       }
-    } catch (e) {
-      overlay.remove();
-      AppLogger.instance.warn("Error when retrieving federation meta: $e");
+
       ToastService().show(
-        message: context.l10n.couldNotGetFederationMetadata,
+        message: context.l10n.joinedFederation(name),
         duration: const Duration(seconds: 5),
         onTap: () {},
-        icon: const Icon(Icons.error),
+        icon: const Icon(Icons.info),
       );
-      setState(() => _gettingMetadata = null);
     }
   }
 
@@ -224,7 +204,7 @@ class _Discover extends State<Discover> with SingleTickerProviderStateMixin {
                 labelStyle: TextStyle(color: Colors.grey[400]),
                 border: InputBorder.none,
               ),
-              enabled: !_isLoadingInvitePreview,
+              enabled: !_isOpeningPreview,
             ),
           ),
           if (_isInviteCodeValid)
@@ -235,15 +215,8 @@ class _Discover extends State<Discover> with SingleTickerProviderStateMixin {
           const SizedBox(width: 8),
           ElevatedButton(
             onPressed:
-                (_isInviteCodeValid &&
-                        !_isLoadingInvitePreview &&
-                        _gettingMetadata == null)
-                    ? () async {
-                      setState(() => _isLoadingInvitePreview = true);
-                      final inviteCode = _inviteCodeController.text.trim();
-                      await _onPreviewPressed(inviteCode);
-                      setState(() => _isLoadingInvitePreview = false);
-                    }
+                (_isInviteCodeValid && !_isOpeningPreview)
+                    ? () => _onPreviewPressed(_inviteCodeController.text.trim())
                     : null,
             style: ElevatedButton.styleFrom(
               backgroundColor: Theme.of(context).colorScheme.primary,
@@ -253,17 +226,7 @@ class _Discover extends State<Discover> with SingleTickerProviderStateMixin {
               ),
               padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
             ),
-            child:
-                _isLoadingInvitePreview
-                    ? const SizedBox(
-                      width: 20,
-                      height: 20,
-                      child: CircularProgressIndicator(
-                        strokeWidth: 2,
-                        color: Colors.black,
-                      ),
-                    )
-                    : Text(context.l10n.preview),
+            child: Text(context.l10n.preview),
           ),
         ],
       ),
@@ -305,12 +268,12 @@ class _Discover extends State<Discover> with SingleTickerProviderStateMixin {
         child: InkWell(
           borderRadius: BorderRadius.circular(20),
           onTap:
-              (_gettingMetadata == null && !_isLoadingInvitePreview)
-                  ? () async {
-                    setState(() => _gettingMetadata = federation);
-                    await _onPreviewPressed(federation.inviteCodes.first);
-                  }
-                  : null,
+              _isOpeningPreview
+                  ? null
+                  : () => _onPreviewPressed(
+                    federation.inviteCodes.first,
+                    previewName: federation.federationName,
+                  ),
           child: Padding(
             padding: const EdgeInsets.all(16),
             child: Row(
@@ -376,36 +339,28 @@ class _Discover extends State<Discover> with SingleTickerProviderStateMixin {
                   ),
                 ),
                 const SizedBox(width: 12),
-                _gettingMetadata == federation
-                    ? const SizedBox(
-                      width: 24,
-                      height: 24,
-                      child: CircularProgressIndicator(strokeWidth: 2),
-                    )
-                    : ElevatedButton.icon(
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: Theme.of(context).colorScheme.primary,
-                        foregroundColor: Colors.black,
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(12),
-                        ),
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 14,
-                          vertical: 10,
-                        ),
-                      ),
-                      onPressed:
-                          (_gettingMetadata == null && !_isLoadingInvitePreview)
-                              ? () async {
-                                setState(() => _gettingMetadata = federation);
-                                await _onPreviewPressed(
-                                  federation.inviteCodes.first,
-                                );
-                              }
-                              : null,
-                      icon: const Icon(Icons.info_outline, size: 18),
-                      label: Text(context.l10n.preview),
+                ElevatedButton.icon(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Theme.of(context).colorScheme.primary,
+                    foregroundColor: Colors.black,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
                     ),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 14,
+                      vertical: 10,
+                    ),
+                  ),
+                  onPressed:
+                      _isOpeningPreview
+                          ? null
+                          : () => _onPreviewPressed(
+                            federation.inviteCodes.first,
+                            previewName: federation.federationName,
+                          ),
+                  icon: const Icon(Icons.info_outline, size: 18),
+                  label: Text(context.l10n.preview),
+                ),
               ],
             ),
           ),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -48,6 +48,8 @@
 
   "loading": "Loading...",
   "@loading": {},
+  "retry": "Retry",
+  "@retry": {},
 
   "offline": "Offline",
   "@offline": {},

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -17,6 +17,7 @@
   "noFederationsFound": "No se encontraron federaciones",
   "recovering": "Recuperando...",
   "loading": "Cargando...",
+  "retry": "Reintentar",
   "offline": "Sin conexión",
   "guardianCount": "{count, plural, =1{1 guardián} other{{count} guardianes}}",
   "retrievingFederationBackup": "Recuperando respaldo de federación de Nostr...",

--- a/lib/screens/federation_info_screen.dart
+++ b/lib/screens/federation_info_screen.dart
@@ -14,7 +14,10 @@ import 'package:qr_flutter/qr_flutter.dart';
 enum _InfoSection { guardians, utxos, gateways }
 
 class FederationInfoScreen extends StatefulWidget {
-  final FederationSelector fed;
+  /// The federation to display. For joinable previews this can be null: the
+  /// screen then downloads the metadata itself (from [inviteCode]) and shows a
+  /// loading state, so the user is never stuck on a blocking spinner.
+  final FederationSelector? fed;
   final String? welcomeMessage;
   final String? imageUrl;
   final VoidCallback onLeaveFederation;
@@ -24,15 +27,19 @@ class FederationInfoScreen extends StatefulWidget {
   final String? inviteCode;
   final String? ecash;
 
+  /// Name shown in the app bar while a joinable preview's metadata loads.
+  final String? previewName;
+
   const FederationInfoScreen({
     super.key,
-    required this.fed,
+    this.fed,
     this.welcomeMessage,
     this.imageUrl,
     required this.onLeaveFederation,
     this.joinable = false,
     this.inviteCode,
     this.ecash,
+    this.previewName,
   });
 
   @override
@@ -41,34 +48,85 @@ class FederationInfoScreen extends StatefulWidget {
 
 class _FederationInfoScreenState extends State<FederationInfoScreen> {
   double _animatedPercent = 0.0;
-  late StreamSubscription<List<PeerStatus>> _peerUpdates;
+  StreamSubscription<List<PeerStatus>>? _peerUpdates;
   List<PeerStatus>? _peers;
   _InfoSection _selectedSection = _InfoSection.guardians;
   bool _isJoining = false;
+
+  // Resolved federation data. Populated immediately from the widget when the
+  // caller already has it, or after [_loadMeta] succeeds for a joinable preview.
+  FederationSelector? _fed;
+  String? _welcomeMessage;
+  String? _imageUrl;
+
+  // Joinable preview loading state.
+  bool _isLoadingMeta = false;
+  Object? _loadError;
 
   @override
   void initState() {
     super.initState();
 
-    Stream<List<PeerStatus>> stream = subscribePeerStatus(
+    if (widget.joinable && widget.fed == null) {
+      // Preview: navigate in immediately and download the metadata here so the
+      // user always has a back button while it loads (or fails).
+      _loadMeta();
+    } else {
+      _fed = widget.fed;
+      _welcomeMessage = widget.welcomeMessage;
+      _imageUrl = widget.imageUrl;
+      _subscribePeers();
+    }
+  }
+
+  @override
+  void dispose() {
+    _peerUpdates?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _loadMeta() async {
+    setState(() {
+      _isLoadingMeta = true;
+      _loadError = null;
+    });
+    try {
+      final meta = await getFederationMeta(inviteCode: widget.inviteCode);
+      if (!mounted) return;
+      setState(() {
+        _fed = meta.selector;
+        _welcomeMessage = meta.welcome;
+        _imageUrl = meta.picture;
+        _isLoadingMeta = false;
+      });
+      _subscribePeers();
+    } catch (e) {
+      AppLogger.instance.warn("Error when retrieving federation meta: $e");
+      if (!mounted) return;
+      setState(() {
+        _isLoadingMeta = false;
+        _loadError = e;
+      });
+    }
+  }
+
+  void _subscribePeers() {
+    final fed = _fed;
+    if (fed == null) return;
+    final stream = subscribePeerStatus(
       invite: widget.joinable ? widget.inviteCode : null,
-      federationId: widget.fed.federationId,
+      federationId: fed.federationId,
     );
     _peerUpdates = stream.listen((List<PeerStatus> event) {
       final onlineCount = event.where((p) => p.online).length;
       final totalCount = event.length;
 
+      if (!mounted) return;
       setState(() {
         _peers = event;
         _animatedPercent = totalCount > 0 ? onlineCount / totalCount : 0.0;
       });
     });
-  }
-
-  @override
-  void dispose() {
-    _peerUpdates.cancel();
-    super.dispose();
   }
 
   // --- Leave federation logic ---
@@ -105,7 +163,7 @@ class _FederationInfoScreenState extends State<FederationInfoScreen> {
 
                             try {
                               await leaveFederation(
-                                federationId: widget.fed.federationId,
+                                federationId: _fed!.federationId,
                               );
                               try {
                                 backupInviteCodes();
@@ -222,7 +280,7 @@ class _FederationInfoScreenState extends State<FederationInfoScreen> {
   Future<void> _redeemEcash(String ecash) async {
     try {
       final isSpent = await checkEcashSpent(
-        federationId: widget.fed.federationId,
+        federationId: _fed!.federationId,
         ecash: ecash,
       );
 
@@ -239,12 +297,12 @@ class _FederationInfoScreenState extends State<FederationInfoScreen> {
       }
 
       final fees = await calculateEcashReissueFees(
-        federationId: widget.fed.federationId,
+        federationId: _fed!.federationId,
         ecash: ecash,
       );
 
       await reissueEcash(
-        federationId: widget.fed.federationId,
+        federationId: _fed!.federationId,
         ecash: ecash,
         fees: fees,
       );
@@ -495,7 +553,7 @@ class _FederationInfoScreenState extends State<FederationInfoScreen> {
                         onPressed: () async {
                           try {
                             final inviteCode = await getInviteCode(
-                              federationId: widget.fed.federationId,
+                              federationId: _fed!.federationId,
                               peer: peer.peerId,
                             );
                             if (!context.mounted) return;
@@ -527,7 +585,7 @@ class _FederationInfoScreenState extends State<FederationInfoScreen> {
                         onPressed: () async {
                           try {
                             final inviteCode = await getInviteCode(
-                              federationId: widget.fed.federationId,
+                              federationId: _fed!.federationId,
                               peer: peer.peerId,
                             );
                             if (!context.mounted) return;
@@ -630,12 +688,12 @@ class _FederationInfoScreenState extends State<FederationInfoScreen> {
       case _InfoSection.utxos:
         return FederationUtxoList(
           invite: widget.joinable ? widget.inviteCode : null,
-          fed: widget.fed,
+          fed: _fed!,
           isFederationOnline: isFederationOnline,
         );
       case _InfoSection.gateways:
         return GatewaysList(
-          fed: widget.fed,
+          fed: _fed!,
           invite: widget.joinable ? widget.inviteCode : null,
         );
     }
@@ -681,9 +739,74 @@ class _FederationInfoScreenState extends State<FederationInfoScreen> {
     );
   }
 
+  /// Shown for a joinable preview while its metadata downloads, or if the
+  /// download fails. Always has a back button (the app bar), so the user can
+  /// cancel instead of being stuck on a spinner, plus a Retry on failure.
+  Widget _buildLoadingOrError(ThemeData theme) {
+    return Scaffold(
+      appBar: AppBar(
+        centerTitle: true,
+        title: Text(widget.previewName ?? context.l10n.loading),
+      ),
+      body: SafeArea(
+        child: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child:
+                _loadError != null
+                    ? Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        const Icon(
+                          Icons.cloud_off,
+                          size: 48,
+                          color: Colors.grey,
+                        ),
+                        const SizedBox(height: 16),
+                        Text(
+                          context.l10n.couldNotGetFederationMetadata,
+                          textAlign: TextAlign.center,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: Colors.grey,
+                          ),
+                        ),
+                        const SizedBox(height: 24),
+                        ElevatedButton.icon(
+                          onPressed: _isLoadingMeta ? null : _loadMeta,
+                          icon: const Icon(Icons.refresh),
+                          label: Text(context.l10n.retry),
+                        ),
+                      ],
+                    )
+                    : Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        const CircularProgressIndicator(),
+                        const SizedBox(height: 16),
+                        Text(
+                          context.l10n.loading,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: Colors.grey,
+                          ),
+                        ),
+                      ],
+                    ),
+          ),
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+
+    // Joinable preview whose metadata hasn't resolved yet (still loading or
+    // failed): show a cancellable loading/error screen instead of the content.
+    if (_fed == null) {
+      return _buildLoadingOrError(theme);
+    }
+
     final totalGuardians = _peers?.length ?? 0;
     final thresh = threshold(totalGuardians);
     final onlineGuardians = _peers?.where((p) => p.online).toList() ?? [];
@@ -693,7 +816,7 @@ class _FederationInfoScreenState extends State<FederationInfoScreen> {
     return Scaffold(
       appBar: AppBar(
         centerTitle: true,
-        title: Text(widget.fed.federationName),
+        title: Text(_fed!.federationName),
         actions: [
           PopupMenuButton<String>(
             icon: const Icon(Icons.more_vert),
@@ -750,9 +873,9 @@ class _FederationInfoScreenState extends State<FederationInfoScreen> {
                       width: 80,
                       height: 80,
                       child:
-                          widget.imageUrl != null
+                          _imageUrl != null
                               ? Image.network(
-                                widget.imageUrl!,
+                                _imageUrl!,
                                 fit: BoxFit.cover,
                                 errorBuilder: (context, error, stackTrace) {
                                   return Image.asset(
@@ -767,18 +890,18 @@ class _FederationInfoScreenState extends State<FederationInfoScreen> {
                               ),
                     ),
                   ),
-                  if (widget.welcomeMessage != null) ...[
+                  if (_welcomeMessage != null) ...[
                     const SizedBox(height: 8),
                     Text(
-                      widget.welcomeMessage!,
+                      _welcomeMessage!,
                       style: theme.textTheme.bodyMedium?.copyWith(
                         color: Colors.grey,
                       ),
                       textAlign: TextAlign.center,
                     ),
                   ],
-                  if (widget.fed.network != null &&
-                      widget.fed.network!.toLowerCase() != 'bitcoin') ...[
+                  if (_fed!.network != null &&
+                      _fed!.network!.toLowerCase() != 'bitcoin') ...[
                     const SizedBox(height: 8),
                     Container(
                       padding: const EdgeInsets.all(8),
@@ -793,7 +916,7 @@ class _FederationInfoScreenState extends State<FederationInfoScreen> {
                           Expanded(
                             child: Text(
                               context.l10n.testNetworkWarning(
-                                widget.fed.network ?? '',
+                                _fed!.network ?? '',
                               ),
                               style: const TextStyle(color: Colors.orange),
                             ),

--- a/rust/ecashapp/src/multimint.rs
+++ b/rust/ecashapp/src/multimint.rs
@@ -1333,7 +1333,16 @@ impl Multimint {
                 let invite =
                     invite.ok_or(anyhow!("Federation ID and Invite cannot both be None"))?;
                 let invite_code = InviteCode::from_str(&invite)?;
-                self.get_or_build_temp_client(invite_code).await?
+                // Building a temporary client downloads the config from the
+                // federation's guardians. If they're unreachable this otherwise
+                // hangs forever, leaving the preview spinner stuck. Bound it so
+                // the caller gets a real error instead.
+                timeout(
+                    Duration::from_secs(15),
+                    self.get_or_build_temp_client(invite_code),
+                )
+                .await
+                .map_err(|_| anyhow!("Timed out downloading federation config from guardians"))??
             }
         };
 

--- a/rust/ecashapp/src/nostr.rs
+++ b/rust/ecashapp/src/nostr.rs
@@ -606,7 +606,7 @@ impl NostrClient {
         let filter = nostr_sdk::Filter::new().kind(nostr_sdk::Kind::from(38173));
         match self
             .nostr_client
-            .fetch_events(filter, Duration::from_secs(10))
+            .fetch_events(filter, Duration::from_secs(1))
             .await
         {
             Ok(events) => {


### PR DESCRIPTION
We currently have an annoying issue in the Discover screen where a spinner is displayed and there is no timeout for getting the client config, which can result in the app just hanging if the selected federation is offline.

This PR introduces a better solution:
1) Adds a timeout to initial download of client config
2) Adds a loading screen to the federation preview, so the user can navigate back if they want to cancel.

Greatly improves the UX of the Discover screen.