### PR TITLE
feat: show txid and fee for pending on-chain receives

### DIFF
--- a/lib/constants/transaction_key_labels.dart
+++ b/lib/constants/transaction_key_labels.dart
@@ -11,6 +11,10 @@ String localizedTxLabel(AppLocalizations l10n, String key) {
     TransactionDetailKeys.receivedAmount => l10n.txDetailReceivedAmount,
     TransactionDetailKeys.fees => l10n.txDetailFees,
     TransactionDetailKeys.federationFee => l10n.txDetailFederationFee,
+    // Reuses the receive screen's fee-component labels so the pending-deposit
+    // breakdown reads identically to the one shown at address generation.
+    TransactionDetailKeys.federationBaseFee => l10n.federationBaseFee,
+    TransactionDetailKeys.federationRate => l10n.federationRate,
     TransactionDetailKeys.onchainClaimFee => l10n.txDetailOnchainClaimFee,
     TransactionDetailKeys.gatewayFee => l10n.txDetailGatewayFee,
     TransactionDetailKeys.bitcoinNetworkFee => l10n.txDetailBitcoinNetworkFee,

--- a/lib/constants/transaction_keys.dart
+++ b/lib/constants/transaction_keys.dart
@@ -9,6 +9,8 @@ class TransactionDetailKeys {
   static const String receivedAmount = 'Received Amount';
   static const String fees = 'Fees';
   static const String federationFee = 'Federation Fee';
+  static const String federationBaseFee = 'Federation Base Fee';
+  static const String federationRate = 'Federation Rate';
   static const String onchainClaimFee = 'On-chain Claim Fee';
   static const String gatewayFee = 'Gateway Fee';
   static const String bitcoinNetworkFee = 'Bitcoin Network Fee';

--- a/lib/frb_generated.dart
+++ b/lib/frb_generated.dart
@@ -13036,13 +13036,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   AwaitingConfsEvent dco_decode_awaiting_confs_event(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 4)
-      throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
+    if (arr.length != 5)
+      throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
     return AwaitingConfsEvent(
       amount: dco_decode_u_64(arr[0]),
       outpoint: dco_decode_String(arr[1]),
       blockHeight: dco_decode_u_64(arr[2]),
       needed: dco_decode_u_64(arr[3]),
+      txid: dco_decode_opt_String(arr[4]),
     );
   }
 
@@ -13248,11 +13249,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ClaimedEvent dco_decode_claimed_event(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 2)
-      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    if (arr.length != 3)
+      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return ClaimedEvent(
       amount: dco_decode_u_64(arr[0]),
       outpoint: dco_decode_String(arr[1]),
+      txid: dco_decode_opt_String(arr[2]),
     );
   }
 
@@ -13260,11 +13262,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ConfirmedEvent dco_decode_confirmed_event(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 2)
-      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    if (arr.length != 3)
+      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return ConfirmedEvent(
       amount: dco_decode_u_64(arr[0]),
       outpoint: dco_decode_String(arr[1]),
+      txid: dco_decode_opt_String(arr[2]),
     );
   }
 
@@ -13870,11 +13873,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MempoolEvent dco_decode_mempool_event(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 2)
-      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    if (arr.length != 3)
+      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return MempoolEvent(
       amount: dco_decode_u_64(arr[0]),
       outpoint: dco_decode_String(arr[1]),
+      txid: dco_decode_opt_String(arr[2]),
     );
   }
 
@@ -15775,11 +15779,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_outpoint = sse_decode_String(deserializer);
     var var_blockHeight = sse_decode_u_64(deserializer);
     var var_needed = sse_decode_u_64(deserializer);
+    var var_txid = sse_decode_opt_String(deserializer);
     return AwaitingConfsEvent(
       amount: var_amount,
       outpoint: var_outpoint,
       blockHeight: var_blockHeight,
       needed: var_needed,
+      txid: var_txid,
     );
   }
 
@@ -16017,7 +16023,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_amount = sse_decode_u_64(deserializer);
     var var_outpoint = sse_decode_String(deserializer);
-    return ClaimedEvent(amount: var_amount, outpoint: var_outpoint);
+    var var_txid = sse_decode_opt_String(deserializer);
+    return ClaimedEvent(
+      amount: var_amount,
+      outpoint: var_outpoint,
+      txid: var_txid,
+    );
   }
 
   @protected
@@ -16025,7 +16036,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_amount = sse_decode_u_64(deserializer);
     var var_outpoint = sse_decode_String(deserializer);
-    return ConfirmedEvent(amount: var_amount, outpoint: var_outpoint);
+    var var_txid = sse_decode_opt_String(deserializer);
+    return ConfirmedEvent(
+      amount: var_amount,
+      outpoint: var_outpoint,
+      txid: var_txid,
+    );
   }
 
   @protected
@@ -16836,7 +16852,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_amount = sse_decode_u_64(deserializer);
     var var_outpoint = sse_decode_String(deserializer);
-    return MempoolEvent(amount: var_amount, outpoint: var_outpoint);
+    var var_txid = sse_decode_opt_String(deserializer);
+    return MempoolEvent(
+      amount: var_amount,
+      outpoint: var_outpoint,
+      txid: var_txid,
+    );
   }
 
   @protected
@@ -18956,6 +18977,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_String(self.outpoint, serializer);
     sse_encode_u_64(self.blockHeight, serializer);
     sse_encode_u_64(self.needed, serializer);
+    sse_encode_opt_String(self.txid, serializer);
   }
 
   @protected
@@ -19223,6 +19245,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_u_64(self.amount, serializer);
     sse_encode_String(self.outpoint, serializer);
+    sse_encode_opt_String(self.txid, serializer);
   }
 
   @protected
@@ -19233,6 +19256,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_u_64(self.amount, serializer);
     sse_encode_String(self.outpoint, serializer);
+    sse_encode_opt_String(self.txid, serializer);
   }
 
   @protected
@@ -19900,6 +19924,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_u_64(self.amount, serializer);
     sse_encode_String(self.outpoint, serializer);
+    sse_encode_opt_String(self.txid, serializer);
   }
 
   @protected

--- a/lib/multimint.dart
+++ b/lib/multimint.dart
@@ -538,12 +538,14 @@ class AwaitingConfsEvent {
   final String outpoint;
   final BigInt blockHeight;
   final BigInt needed;
+  final String? txid;
 
   const AwaitingConfsEvent({
     required this.amount,
     required this.outpoint,
     required this.blockHeight,
     required this.needed,
+    this.txid,
   });
 
   @override
@@ -551,7 +553,8 @@ class AwaitingConfsEvent {
       amount.hashCode ^
       outpoint.hashCode ^
       blockHeight.hashCode ^
-      needed.hashCode;
+      needed.hashCode ^
+      txid.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -561,17 +564,19 @@ class AwaitingConfsEvent {
           amount == other.amount &&
           outpoint == other.outpoint &&
           blockHeight == other.blockHeight &&
-          needed == other.needed;
+          needed == other.needed &&
+          txid == other.txid;
 }
 
 class ClaimedEvent {
   final BigInt amount;
   final String outpoint;
+  final String? txid;
 
-  const ClaimedEvent({required this.amount, required this.outpoint});
+  const ClaimedEvent({required this.amount, required this.outpoint, this.txid});
 
   @override
-  int get hashCode => amount.hashCode ^ outpoint.hashCode;
+  int get hashCode => amount.hashCode ^ outpoint.hashCode ^ txid.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -579,17 +584,23 @@ class ClaimedEvent {
       other is ClaimedEvent &&
           runtimeType == other.runtimeType &&
           amount == other.amount &&
-          outpoint == other.outpoint;
+          outpoint == other.outpoint &&
+          txid == other.txid;
 }
 
 class ConfirmedEvent {
   final BigInt amount;
   final String outpoint;
+  final String? txid;
 
-  const ConfirmedEvent({required this.amount, required this.outpoint});
+  const ConfirmedEvent({
+    required this.amount,
+    required this.outpoint,
+    this.txid,
+  });
 
   @override
-  int get hashCode => amount.hashCode ^ outpoint.hashCode;
+  int get hashCode => amount.hashCode ^ outpoint.hashCode ^ txid.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -597,7 +608,8 @@ class ConfirmedEvent {
       other is ConfirmedEvent &&
           runtimeType == other.runtimeType &&
           amount == other.amount &&
-          outpoint == other.outpoint;
+          outpoint == other.outpoint &&
+          txid == other.txid;
 }
 
 @freezed
@@ -1132,10 +1144,16 @@ class MempoolEvent {
   final BigInt amount;
   final String outpoint;
 
-  const MempoolEvent({required this.amount, required this.outpoint});
+  /// The on-chain transaction id. `outpoint` is a correlation key that, for
+  /// walletv2, is actually the receive address rather than `txid:vout`
+  /// (see `track_pegin_confirmation`), so this field is the only reliable
+  /// source of the txid for display purposes.
+  final String? txid;
+
+  const MempoolEvent({required this.amount, required this.outpoint, this.txid});
 
   @override
-  int get hashCode => amount.hashCode ^ outpoint.hashCode;
+  int get hashCode => amount.hashCode ^ outpoint.hashCode ^ txid.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -1143,7 +1161,8 @@ class MempoolEvent {
       other is MempoolEvent &&
           runtimeType == other.runtimeType &&
           amount == other.amount &&
-          outpoint == other.outpoint;
+          outpoint == other.outpoint &&
+          txid == other.txid;
 }
 
 @freezed

--- a/lib/screens/dashboard.dart
+++ b/lib/screens/dashboard.dart
@@ -601,6 +601,7 @@ class _DashboardState extends State<Dashboard> {
                               if (index < _pendingDeposits.length) {
                                 return PendingDepositItem(
                                   event: _pendingDeposits[index],
+                                  fed: widget.fed,
                                 );
                               }
                               final tx =

--- a/lib/widgets/pending_deposit_details.dart
+++ b/lib/widgets/pending_deposit_details.dart
@@ -1,0 +1,104 @@
+import 'package:ecashapp/constants/transaction_key_labels.dart';
+import 'package:ecashapp/constants/transaction_keys.dart';
+import 'package:ecashapp/detail_row.dart';
+import 'package:ecashapp/extensions/build_context_l10n.dart';
+import 'package:ecashapp/multimint.dart';
+import 'package:ecashapp/utils.dart';
+import 'package:flutter/material.dart';
+
+class PendingDepositDetails extends StatelessWidget {
+  final Icon icon;
+  final String statusMessage;
+  final Map<String, String> details;
+  final String? txid;
+  final FederationSelector fed;
+
+  const PendingDepositDetails({
+    super.key,
+    required this.icon,
+    required this.statusMessage,
+    required this.details,
+    required this.txid,
+    required this.fed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final explorerUrl =
+        txid != null ? explorerUrlForNetwork(txid!, fed.network) : null;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Icon(icon.icon, color: theme.colorScheme.primary, size: 24),
+            const SizedBox(width: 8),
+            Text(
+              context.l10n.pendingReceive,
+              style: theme.textTheme.headlineSmall?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: theme.colorScheme.primary,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        Text(statusMessage, style: theme.textTheme.bodyMedium),
+        const SizedBox(height: 24),
+        Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: theme.colorScheme.surfaceContainer,
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(
+              color: theme.colorScheme.primary.withOpacity(0.25),
+            ),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children:
+                details.entries.map((entry) {
+                  if (entry.key == TransactionDetailKeys.txid) {
+                    return CopyableDetailRow(
+                      label: localizedTxLabel(context.l10n, entry.key),
+                      value: entry.value,
+                      abbreviate: true,
+                      additionalAction:
+                          explorerUrl != null
+                              ? Padding(
+                                padding: const EdgeInsets.only(left: 8),
+                                child: IconButton(
+                                  tooltip: context.l10n.viewOnBlockExplorer,
+                                  iconSize: 20,
+                                  padding: EdgeInsets.zero,
+                                  visualDensity: VisualDensity.compact,
+                                  icon: Icon(
+                                    Icons.open_in_new,
+                                    color: theme.colorScheme.secondary,
+                                  ),
+                                  onPressed:
+                                      () async =>
+                                          await showExplorerConfirmation(
+                                            context,
+                                            Uri.parse(explorerUrl),
+                                          ),
+                                ),
+                              )
+                              : null,
+                    );
+                  }
+
+                  return CopyableDetailRow(
+                    label: localizedTxLabel(context.l10n, entry.key),
+                    value: entry.value,
+                  );
+                }).toList(),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/pending_deposit_item.dart
+++ b/lib/widgets/pending_deposit_item.dart
@@ -1,15 +1,80 @@
 import 'package:flutter/material.dart';
+import 'package:ecashapp/constants/transaction_keys.dart';
 import 'package:ecashapp/db.dart';
 import 'package:ecashapp/extensions/build_context_l10n.dart';
+import 'package:ecashapp/lib.dart';
 import 'package:ecashapp/multimint.dart';
 import 'package:ecashapp/providers/preferences_provider.dart';
+import 'package:ecashapp/theme.dart';
 import 'package:ecashapp/utils.dart';
+import 'package:ecashapp/widgets/pending_deposit_details.dart';
 import 'package:provider/provider.dart';
 
 class PendingDepositItem extends StatelessWidget {
   final DepositEventKind event;
+  final FederationSelector fed;
 
-  const PendingDepositItem({super.key, required this.event});
+  const PendingDepositItem({super.key, required this.event, required this.fed});
+
+  /// ppm → percentage: 10,000 ppm equals 1%. Mirrors the receive screen.
+  String _formatRate(BigInt partsPerMillion) {
+    final percent = partsPerMillion.toDouble() / 10000.0;
+    return '${percent.toStringAsFixed(2)}% ($partsPerMillion ppm)';
+  }
+
+  void _onTap(
+    BuildContext context,
+    String msg,
+    BigInt amount,
+    String? txid,
+    BitcoinDisplay bitcoinDisplay,
+  ) {
+    // Resolved before the await below so the async builder never reaches back
+    // into a BuildContext across an async gap.
+    final noFeeConfigured = context.l10n.noFeeConfigured;
+    showAppModalBottomSheet(
+      context: context,
+      childBuilder: () async {
+        final feeQuote = await getPeginFeeQuote(federationId: fed.federationId);
+        return PendingDepositDetails(
+          icon: const Icon(Icons.link, color: Colors.yellowAccent),
+          statusMessage: msg,
+          txid: txid,
+          fed: fed,
+          details: {
+            TransactionDetailKeys.amount: formatBalance(
+              amount,
+              false,
+              bitcoinDisplay,
+            ),
+            if (txid != null) TransactionDetailKeys.txid: txid,
+            // The peg-in fee has no single total: walletv2 scales the
+            // federation fee with the deposit amount and adds a dynamic claim
+            // fee, so surface the same components the receive screen does
+            // rather than presenting a computed figure as authoritative.
+            TransactionDetailKeys.federationBaseFee:
+                feeQuote.baseFeeMsats == BigInt.zero
+                    ? noFeeConfigured
+                    : formatBalance(
+                      feeQuote.baseFeeMsats,
+                      false,
+                      bitcoinDisplay,
+                    ),
+            if (feeQuote.partsPerMillion > BigInt.zero)
+              TransactionDetailKeys.federationRate: _formatRate(
+                feeQuote.partsPerMillion,
+              ),
+            if (feeQuote.onchainClaimFeeSats != null)
+              TransactionDetailKeys.onchainClaimFee: formatBalance(
+                feeQuote.onchainClaimFeeSats! * BigInt.from(1000),
+                false,
+                bitcoinDisplay,
+              ),
+          },
+        );
+      },
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -18,11 +83,13 @@ class PendingDepositItem extends StatelessWidget {
     );
     String msg;
     BigInt amount;
+    String? txid;
 
     switch (event) {
       case DepositEventKind_Mempool(field0: final e):
         msg = context.l10n.txInMempool;
         amount = e.amount;
+        txid = e.txid;
         break;
       case DepositEventKind_AwaitingConfs(field0: final e):
         // Once the tx is fully confirmed (0 confs left), the on-chain wait is
@@ -37,10 +104,12 @@ class PendingDepositItem extends StatelessWidget {
                   e.needed.toString(),
                 );
         amount = e.amount;
+        txid = e.txid;
         break;
       case DepositEventKind_Confirmed(field0: final e):
         msg = context.l10n.txConfirmedClaimingEcash;
         amount = e.amount;
+        txid = e.txid;
         break;
       case DepositEventKind_Claimed():
         return const SizedBox.shrink();
@@ -57,6 +126,7 @@ class PendingDepositItem extends StatelessWidget {
       margin: const EdgeInsets.symmetric(vertical: 6),
       color: Theme.of(context).colorScheme.surface,
       child: ListTile(
+        onTap: () => _onTap(context, msg, amount, txid, bitcoinDisplay),
         leading: CircleAvatar(
           backgroundColor: Theme.of(
             context,

--- a/lib/widgets/transactions_list.dart
+++ b/lib/widgets/transactions_list.dart
@@ -229,7 +229,7 @@ class _TransactionsListState extends State<TransactionsList> {
     return ListView(
       controller: _scrollController,
       children: [
-        ...pending.map((e) => PendingDepositItem(event: e)),
+        ...pending.map((e) => PendingDepositItem(event: e, fed: widget.fed)),
         ..._transactions.map((tx) => TransactionItem(tx: tx, fed: widget.fed)),
         if (_hasMore)
           const Padding(

--- a/rust/ecashapp/src/frb_generated.rs
+++ b/rust/ecashapp/src/frb_generated.rs
@@ -15769,11 +15769,13 @@ impl SseDecode for crate::multimint::AwaitingConfsEvent {
         let mut var_outpoint = <String>::sse_decode(deserializer);
         let mut var_blockHeight = <u64>::sse_decode(deserializer);
         let mut var_needed = <u64>::sse_decode(deserializer);
+        let mut var_txid = <Option<String>>::sse_decode(deserializer);
         return crate::multimint::AwaitingConfsEvent {
             amount: var_amount,
             outpoint: var_outpoint,
             block_height: var_blockHeight,
             needed: var_needed,
+            txid: var_txid,
         };
     }
 }
@@ -15804,9 +15806,11 @@ impl SseDecode for crate::multimint::ClaimedEvent {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_amount = <u64>::sse_decode(deserializer);
         let mut var_outpoint = <String>::sse_decode(deserializer);
+        let mut var_txid = <Option<String>>::sse_decode(deserializer);
         return crate::multimint::ClaimedEvent {
             amount: var_amount,
             outpoint: var_outpoint,
+            txid: var_txid,
         };
     }
 }
@@ -15816,9 +15820,11 @@ impl SseDecode for crate::multimint::ConfirmedEvent {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_amount = <u64>::sse_decode(deserializer);
         let mut var_outpoint = <String>::sse_decode(deserializer);
+        let mut var_txid = <Option<String>>::sse_decode(deserializer);
         return crate::multimint::ConfirmedEvent {
             amount: var_amount,
             outpoint: var_outpoint,
+            txid: var_txid,
         };
     }
 }
@@ -16656,9 +16662,11 @@ impl SseDecode for crate::multimint::MempoolEvent {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_amount = <u64>::sse_decode(deserializer);
         let mut var_outpoint = <String>::sse_decode(deserializer);
+        let mut var_txid = <Option<String>>::sse_decode(deserializer);
         return crate::multimint::MempoolEvent {
             amount: var_amount,
             outpoint: var_outpoint,
+            txid: var_txid,
         };
     }
 }
@@ -18961,6 +18969,7 @@ impl flutter_rust_bridge::IntoDart for crate::multimint::AwaitingConfsEvent {
             self.outpoint.into_into_dart().into_dart(),
             self.block_height.into_into_dart().into_dart(),
             self.needed.into_into_dart().into_dart(),
+            self.txid.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -19000,6 +19009,7 @@ impl flutter_rust_bridge::IntoDart for crate::multimint::ClaimedEvent {
         [
             self.amount.into_into_dart().into_dart(),
             self.outpoint.into_into_dart().into_dart(),
+            self.txid.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -19021,6 +19031,7 @@ impl flutter_rust_bridge::IntoDart for crate::multimint::ConfirmedEvent {
         [
             self.amount.into_into_dart().into_dart(),
             self.outpoint.into_into_dart().into_dart(),
+            self.txid.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -19692,6 +19703,7 @@ impl flutter_rust_bridge::IntoDart for crate::multimint::MempoolEvent {
         [
             self.amount.into_into_dart().into_dart(),
             self.outpoint.into_into_dart().into_dart(),
+            self.txid.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -20913,6 +20925,7 @@ impl SseEncode for crate::multimint::AwaitingConfsEvent {
         <String>::sse_encode(self.outpoint, serializer);
         <u64>::sse_encode(self.block_height, serializer);
         <u64>::sse_encode(self.needed, serializer);
+        <Option<String>>::sse_encode(self.txid, serializer);
     }
 }
 
@@ -20946,6 +20959,7 @@ impl SseEncode for crate::multimint::ClaimedEvent {
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <u64>::sse_encode(self.amount, serializer);
         <String>::sse_encode(self.outpoint, serializer);
+        <Option<String>>::sse_encode(self.txid, serializer);
     }
 }
 
@@ -20954,6 +20968,7 @@ impl SseEncode for crate::multimint::ConfirmedEvent {
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <u64>::sse_encode(self.amount, serializer);
         <String>::sse_encode(self.outpoint, serializer);
+        <Option<String>>::sse_encode(self.txid, serializer);
     }
 }
 
@@ -21628,6 +21643,7 @@ impl SseEncode for crate::multimint::MempoolEvent {
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <u64>::sse_encode(self.amount, serializer);
         <String>::sse_encode(self.outpoint, serializer);
+        <Option<String>>::sse_encode(self.txid, serializer);
     }
 }
 

--- a/rust/ecashapp/src/multimint.rs
+++ b/rust/ecashapp/src/multimint.rs
@@ -595,6 +595,11 @@ impl fmt::Display for ClientType {
 pub struct MempoolEvent {
     pub amount: u64,
     pub outpoint: String,
+    /// The on-chain transaction id. `outpoint` is a correlation key that, for
+    /// walletv2, is actually the receive address rather than `txid:vout`
+    /// (see `track_pegin_confirmation`), so this field is the only reliable
+    /// source of the txid for display purposes.
+    pub txid: Option<String>,
 }
 
 #[derive(Clone, Eq, PartialEq, Serialize, Debug)]
@@ -603,18 +608,21 @@ pub struct AwaitingConfsEvent {
     pub outpoint: String,
     pub block_height: u64,
     pub needed: u64,
+    pub txid: Option<String>,
 }
 
 #[derive(Clone, Eq, PartialEq, Serialize, Debug)]
 pub struct ConfirmedEvent {
     pub amount: u64,
     pub outpoint: String,
+    pub txid: Option<String>,
 }
 
 #[derive(Clone, Eq, PartialEq, Serialize, Debug)]
 pub struct ClaimedEvent {
     pub amount: u64,
     pub outpoint: String,
+    pub txid: Option<String>,
 }
 
 #[derive(Clone, Eq, PartialEq, Serialize, Debug)]

--- a/rust/ecashapp/src/wallet/mod.rs
+++ b/rust/ecashapp/src/wallet/mod.rs
@@ -187,6 +187,7 @@ impl WalletHandler {
                         DepositEventKind::Confirmed(ConfirmedEvent {
                             amount: Amount::from_sats(btc_deposited.to_sat()).msats,
                             outpoint: btc_out_point.to_string(),
+                            txid: Some(btc_out_point.txid.to_string()),
                         }),
                     ));
 
@@ -201,6 +202,7 @@ impl WalletHandler {
                         DepositEventKind::Claimed(ClaimedEvent {
                             amount: Amount::from_sats(btc_deposited.to_sat()).msats,
                             outpoint: btc_out_point.to_string(),
+                            txid: Some(btc_out_point.txid.to_string()),
                         }),
                     ));
 
@@ -696,6 +698,7 @@ impl WalletHandler {
                         let deposited_sats = receive_event.value.to_sat();
                         let amount_msats = Amount::from_sats(deposited_sats).msats;
                         let operation_id = receive_event.operation_id;
+                        let txid = receive_event.outpoint.map(|op| op.txid.to_string());
 
                         info_to_flutter(format!(
                             "spawn_v2_deposit_event_listener: ReceivePaymentEvent for fed {federation_id} address={address} amount={amount_msats} msats op={operation_id:?}, publishing Confirmed"
@@ -716,6 +719,7 @@ impl WalletHandler {
                                 DepositEventKind::Confirmed(ConfirmedEvent {
                                     amount: amount_msats,
                                     outpoint: address.clone(),
+                                    txid: txid.clone(),
                                 }),
                             )))
                             .await;
@@ -777,6 +781,7 @@ impl WalletHandler {
                                             DepositEventKind::Claimed(ClaimedEvent {
                                                 amount: amount_msats,
                                                 outpoint: address,
+                                                txid,
                                             }),
                                         )))
                                         .await;
@@ -1183,6 +1188,7 @@ where
             DepositEventKind::Mempool(MempoolEvent {
                 amount: amount_msats,
                 outpoint: outpoint_label.clone(),
+                txid: Some(txid.to_string()),
             }),
         )))
         .await;
@@ -1240,6 +1246,7 @@ where
                     outpoint: outpoint_label.clone(),
                     block_height: tx_height,
                     needed,
+                    txid: Some(txid.to_string()),
                 }),
             )))
             .await;


### PR DESCRIPTION
Make the pending on-chain deposit card tappable, opening a detail sheet with amount, txid, and peg-in fee, matching the existing detail view for completed transactions (fixes #479).

Threads a `txid` field through the Mempool/AwaitingConfs/Confirmed/ Claimed deposit events on the Rust side rather than deriving it in Dart from the existing `outpoint` field. For walletv2, `outpoint` is actually the receive address, not `txid:vout` (the walletv2 event log identifies deposits by address), so parsing it client-side would have shown the wrong value for every walletv2 deposit, the default module for new gateways.