### PR TITLE
fix: add guards around sending flows

### DIFF
--- a/lib/ecash_send.dart
+++ b/lib/ecash_send.dart
@@ -42,6 +42,11 @@ class _EcashSendState extends State<EcashSend> {
   EcashSendFees? _fees;
   // Generating the ecash — this is the step that actually spends.
   bool _generating = false;
+
+  /// Re-entrancy guard for [_generateEcash]. Distinct from [_generating],
+  /// which drives the loading screen and is only set once the send is
+  /// genuinely in flight — this covers the earlier PIN-prompt gap too.
+  bool _confirming = false;
   bool _copied = false;
   _QrMode _mode = _QrMode.legacy;
 
@@ -78,10 +83,23 @@ class _EcashSendState extends State<EcashSend> {
   /// Actually performs the send: this is where the ecash is taken from the
   /// wallet. Only invoked once the user confirms on the review screen.
   Future<void> _generateEcash() async {
-    final authorized = await checkSpendingPin(context);
-    if (!authorized) return;
-    setState(() => _generating = true);
+    // Claimed synchronously, before the first `await`. Dart runs this isolate
+    // on a single thread, so a check-and-set with no await between the two is
+    // a complete guard.
+    //
+    // It has to happen before the PIN prompt, not after: with the spending PIN
+    // switched off `checkSpendingPin` returns almost immediately, and a double
+    // tap in that window used to run two sends. That debits the wallet twice
+    // and the second `setState` overwrites `_notes`, so the first token is
+    // never rendered or copied — unrecoverable from the UI.
+    if (_confirming) return;
+    _confirming = true;
     try {
+      final authorized = await checkSpendingPin(context);
+      if (!authorized) return;
+      if (!mounted) return;
+      setState(() => _generating = true);
+
       final notes = await sendEcash(
         federationId: widget.fed.federationId,
         amountMsats: widget.amountMsats,
@@ -102,8 +120,9 @@ class _EcashSendState extends State<EcashSend> {
     } catch (e) {
       AppLogger.instance.error("Could not send Ecash: $e");
       if (mounted) showErrorToast(context, e);
-      if (!mounted) return;
-      setState(() => _generating = false);
+      if (mounted) setState(() => _generating = false);
+    } finally {
+      _confirming = false;
     }
   }
 

--- a/lib/onchain_send.dart
+++ b/lib/onchain_send.dart
@@ -46,6 +46,10 @@ class _OnchainSendState extends State<OnchainSend> {
   WithdrawFees? _fees;
   bool _loadingFees = false;
   bool _withdrawing = false;
+
+  /// Re-entrancy guard for [_withdraw], covering the PIN-prompt gap that
+  /// [_withdrawing] leaves open.
+  bool _confirming = false;
   DateTime? _quoteExpiry;
   Timer? _quoteTimer;
 
@@ -178,12 +182,26 @@ class _OnchainSendState extends State<OnchainSend> {
       return;
     }
 
-    final authorized = await checkSpendingPin(context);
-    if (!authorized) return;
+    // Claimed before the first `await`. `_withdrawing` is only set after the
+    // PIN prompt returns, which leaves a window where a double tap produces two
+    // identical on-chain withdrawals.
+    if (_confirming) return;
+    _confirming = true;
+    try {
+      final authorized = await checkSpendingPin(context);
+      if (!authorized) return;
+      if (!mounted) return;
 
-    _quoteTimer?.cancel();
-    setState(() => _withdrawing = true);
+      _quoteTimer?.cancel();
+      setState(() => _withdrawing = true);
 
+      await _performWithdraw();
+    } finally {
+      _confirming = false;
+    }
+  }
+
+  Future<void> _performWithdraw() async {
     try {
       final operationId = await withdrawToAddress(
         federationId: widget.fed.federationId,

--- a/lib/pay_preview.dart
+++ b/lib/pay_preview.dart
@@ -42,6 +42,10 @@ class _PaymentPreviewWidgetState extends State<PaymentPreviewWidget> {
   late String _invoice;
   bool _reloadingPreview = false;
 
+  /// Re-entrancy guard for the send button, covering the PIN-prompt gap and
+  /// the lifetime of the pushed payment screen.
+  bool _confirming = false;
+
   @override
   void initState() {
     super.initState();
@@ -349,29 +353,39 @@ class _PaymentPreviewWidgetState extends State<PaymentPreviewWidget> {
               ),
             ),
             onPressed:
-                _reloadingPreview
+                (_reloadingPreview || _confirming)
                     ? null
                     : () async {
-                      final authorized = await checkSpendingPin(context);
-                      if (!authorized) return;
-                      if (!context.mounted) return;
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder:
-                              (context) => SendPayment(
-                                fed: _selectedFed,
-                                invoice: _previewData.invoice,
-                                lnAddress: widget.lnAddress,
-                                amountMsats: amount,
-                                gateway: _selectedPreview.gateway.endpoint,
-                                isLnv2: _selectedPreview.gateway.isLnv2,
-                                amountMsatsWithFees: amountWithFees,
-                                federationFeeMsats: federationFee,
-                                gatewayFeeMsats: gatewayFee,
-                              ),
-                        ),
-                      );
+                      // Claimed before the PIN prompt: two taps in that gap
+                      // used to push two payment screens, each paying the same
+                      // invoice. Reset only after the pushed route is popped,
+                      // so the button stays inert while the payment runs.
+                      if (_confirming) return;
+                      setState(() => _confirming = true);
+                      try {
+                        final authorized = await checkSpendingPin(context);
+                        if (!authorized) return;
+                        if (!context.mounted) return;
+                        await Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder:
+                                (context) => SendPayment(
+                                  fed: _selectedFed,
+                                  invoice: _previewData.invoice,
+                                  lnAddress: widget.lnAddress,
+                                  amountMsats: amount,
+                                  gateway: _selectedPreview.gateway.endpoint,
+                                  isLnv2: _selectedPreview.gateway.isLnv2,
+                                  amountMsatsWithFees: amountWithFees,
+                                  federationFeeMsats: federationFee,
+                                  gatewayFeeMsats: gatewayFee,
+                                ),
+                          ),
+                        );
+                      } finally {
+                        if (mounted) setState(() => _confirming = false);
+                      }
                     },
           ),
         ),


### PR DESCRIPTION
Adding send guards so that accidentally pressing send twice doesn't debit the user twice.