### PR TITLE
fix: add timeouts to all HTTP calls

### DIFF
--- a/rust/ecashapp/src/http.rs
+++ b/rust/ecashapp/src/http.rs
@@ -1,0 +1,75 @@
+//! Shared HTTP clients and the timeout policy for every outbound request the
+//! Rust core makes.
+//!
+//! `reqwest` sets neither a default request timeout nor a default connect
+//! timeout, so a bare `reqwest::Client::new()` can hang for as long as the OS
+//! TCP stack allows — minutes on a stalled mobile radio, and effectively
+//! forever against a black-holed (silently dropped) connection. That matters
+//! well beyond the individual call: `Multimint::spawn_cache_task` runs its
+//! steps strictly serially, so one hung request there blocks the federation
+//! ecash backup that runs later in the same loop, and the esplora deposit
+//! pollers only advance their retry backoff when a request returns `Err`.
+//!
+//! Everything routes through the clients below so the policy lives in one
+//! place, and so connections and TLS sessions are actually pooled rather than
+//! renegotiated per call.
+
+use std::sync::LazyLock;
+use std::time::Duration;
+
+/// Cap on TCP connect + TLS handshake, applied to every request.
+pub const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Default total-request budget: mutating calls and background tasks.
+///
+/// Mutating calls get the longest budget deliberately — abandoning a
+/// POST/DELETE early leaves ambiguous server-side state.
+pub const BACKGROUND: Duration = Duration::from_secs(30);
+
+/// Read-only calls made with the user waiting on a spinner.
+pub const INTERACTIVE: Duration = Duration::from_secs(15);
+
+/// Calls that fire repeatedly, or whose failure is not user-visible and must
+/// not delay the caller (price fetch, availability probes, version check).
+pub const QUICK: Duration = Duration::from_secs(10);
+
+static CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
+    reqwest::Client::builder()
+        .connect_timeout(CONNECT_TIMEOUT)
+        .timeout(BACKGROUND)
+        .build()
+        .expect("reqwest client with static config always builds")
+});
+
+/// Shared, connection-pooled HTTP client.
+///
+/// Deliberately sets no `User-Agent`: most call sites talk to user- or
+/// federation-supplied hosts, and a version string would fingerprint the
+/// wallet. `Multimint::check_for_update` sets one per-request, since the
+/// GitHub API rejects requests without it.
+///
+/// Requests inherit [`BACKGROUND`]; override with `.timeout(http::INTERACTIVE)`
+/// or `.timeout(http::QUICK)` where a tighter bound fits better.
+pub fn client() -> &'static reqwest::Client {
+    &CLIENT
+}
+
+static LNURL_CLIENT: LazyLock<lnurl::AsyncClient> = LazyLock::new(|| {
+    lnurl::AsyncClient::from_client(
+        reqwest::Client::builder()
+            .connect_timeout(CONNECT_TIMEOUT)
+            .timeout(INTERACTIVE)
+            .build()
+            .expect("reqwest client with static config always builds"),
+    )
+});
+
+/// Shared client for LNURL flows.
+///
+/// `lnurl-rs`'s `make_request` / `get_invoice` accept no per-request timeout,
+/// so the bound has to live on the client itself — hence a second client
+/// rather than a `.timeout()` override on [`client`]. A full LNURL flow is two
+/// round trips, so its worst case is `2 * INTERACTIVE`.
+pub fn lnurl_client() -> &'static lnurl::AsyncClient {
+    &LNURL_CLIENT
+}

--- a/rust/ecashapp/src/lib.rs
+++ b/rust/ecashapp/src/lib.rs
@@ -7,6 +7,7 @@ mod db;
 mod event_bus;
 mod fountain;
 mod frb_generated;
+mod http;
 mod multimint;
 mod nostr;
 mod parse;
@@ -311,7 +312,7 @@ pub async fn get_invoice_from_lnaddress_or_lnurl(
             .map_err(|e| EcashAppError::InvalidLightningAddress(e.to_string()))?,
     };
 
-    let async_client = lnurl::AsyncClient::from_client(reqwest::Client::new());
+    let async_client = http::lnurl_client();
     let response = async_client
         .make_request(&lnurl.url)
         .await
@@ -350,8 +351,9 @@ pub struct LnurlWithdrawParams {
 /// withdraw details and get user confirmation before any money moves.
 #[frb]
 pub async fn fetch_lnurl_withdraw(url: String) -> anyhow::Result<LnurlWithdrawParams> {
-    let resp: serde_json::Value = reqwest::Client::new()
+    let resp: serde_json::Value = http::client()
         .get(&url)
+        .timeout(http::INTERACTIVE)
         .send()
         .await?
         .json()
@@ -429,7 +431,10 @@ pub async fn execute_lnurl_withdraw(
 
     // Hand the invoice to the Boltcard/LNURLw service via the callback URL.
     let callback_url = build_lnurlw_callback_url(&callback, &k1, &invoice.to_string());
-    let resp: serde_json::Value = reqwest::Client::new()
+    // Inherits the default `BACKGROUND` budget rather than the tighter
+    // interactive one: the receive invoice is already minted at this point, so
+    // giving up early leaves the withdraw in an ambiguous state.
+    let resp: serde_json::Value = http::client()
         .get(&callback_url)
         .send()
         .await?
@@ -462,7 +467,7 @@ pub async fn send_lnaddress(
     let lnurl = lnurl::lightning_address::LightningAddress::from_str(&address)
         .map_err(|e| EcashAppError::InvalidLightningAddress(e.to_string()))?
         .lnurl();
-    let async_client = lnurl::AsyncClient::from_client(reqwest::Client::new());
+    let async_client = http::lnurl_client();
     let response = async_client
         .make_request(&lnurl.url)
         .await
@@ -961,7 +966,7 @@ impl parse::ParseContext for MultimintParseContext {
             _ => lnurl::lnurl::LnUrl::from_str(lnurl_or_address)?,
         };
 
-        let async_client = lnurl::AsyncClient::from_client(reqwest::Client::new());
+        let async_client = http::lnurl_client();
         let response = async_client.make_request(&lnurl.url).await?;
         let pay_response = match response {
             lnurl::LnUrlResponse::LnUrlPayResponse(r) => r,
@@ -1057,10 +1062,10 @@ pub async fn check_ecash_spent(
 #[frb]
 pub async fn list_ln_address_domains(ln_address_api: String) -> anyhow::Result<Vec<String>> {
     let safe_ln_address_api = SafeUrl::parse(&ln_address_api)?.join("domains")?;
-    let http_client = reqwest::Client::new();
     let url = safe_ln_address_api.to_unsafe();
-    let result = http_client
+    let result = http::client()
         .get(url)
+        .timeout(http::INTERACTIVE)
         .send()
         .await
         .context("Failed to send domains request")?;

--- a/rust/ecashapp/src/multimint.rs
+++ b/rust/ecashapp/src/multimint.rs
@@ -109,7 +109,7 @@ use crate::{
         LightningAddressKey, LightningAddressKeyPrefix, PinCodeHashKey, RequirePinForSpendingKey,
         SchemaVersionKey,
     },
-    error_to_flutter, get_nostr_client, info_to_flutter, payment_error_to_flutter,
+    error_to_flutter, get_nostr_client, http, info_to_flutter, payment_error_to_flutter,
     wallet::WalletHandler,
     FederationConfig, FederationConfigKey, FederationConfigKeyPrefix, SeedPhraseAckKey,
 };
@@ -1294,16 +1294,19 @@ impl Multimint {
     }
 
     async fn check_for_update(&self) {
-        let client = match reqwest::Client::builder()
-            .user_agent(concat!("ecash-app/", env!("CARGO_PKG_VERSION")))
-            .timeout(Duration::from_secs(10))
-            .build()
+        // The shared client sets no `User-Agent` (it would fingerprint the
+        // wallet to the user-supplied hosts every other call site talks to),
+        // but the GitHub API rejects requests without one, so set it here.
+        let response = match http::client()
+            .get(GITHUB_LATEST_RELEASE_URL)
+            .header(
+                reqwest::header::USER_AGENT,
+                concat!("ecash-app/", env!("CARGO_PKG_VERSION")),
+            )
+            .timeout(http::QUICK)
+            .send()
+            .await
         {
-            Ok(c) => c,
-            Err(_) => return,
-        };
-
-        let response = match client.get(GITHUB_LATEST_RELEASE_URL).send().await {
             Ok(r) => r,
             Err(_) => return,
         };
@@ -1368,7 +1371,10 @@ impl Multimint {
 
     async fn cache_btc_price(&self, now: std::time::SystemTime) {
         let url = "https://mempool.space/api/v1/prices";
-        let Ok(response) = reqwest::get(url).await else {
+        // Kept short on purpose: this runs inside the strictly serial cache
+        // loop, which reaches the federation ecash backup only after it
+        // returns. A stalled price fetch must never hold that up.
+        let Ok(response) = http::client().get(url).timeout(http::QUICK).send().await else {
             error_to_flutter("BTC Price GET returned error").await;
             return;
         };
@@ -4844,9 +4850,8 @@ impl Multimint {
                 authentication_token: config.authentication_token,
             };
 
-            let http_client = reqwest::Client::new();
             let remove_endpoint = safe_ln_address_api.join("lnaddress/remove")?;
-            let result = http_client
+            let result = http::client()
                 .delete(remove_endpoint.to_unsafe())
                 .json(&remove_request)
                 .send()
@@ -4932,9 +4937,8 @@ impl Multimint {
             recipient_pk: recipient_pk.clone(),
         };
 
-        let http_client = reqwest::Client::new();
         let register_endpoint = safe_ln_address_api.join("lnaddress/register")?;
-        let result = http_client
+        let result = http::client()
             .post(register_endpoint.to_unsafe())
             .json(&register_request)
             .send()
@@ -5030,7 +5034,7 @@ impl Multimint {
             .clone();
 
         let safe_ln_address_api = SafeUrl::parse(ln_address_api)?;
-        let http_client = reqwest::Client::new();
+        let http_client = http::client();
 
         // Try LNv2 first: generate LNURL with a dummy gateway to extract recipient_pk
         let mut recovered_pk: Option<String> = None;
@@ -5363,9 +5367,9 @@ impl Multimint {
 
         let safe_url = SafeUrl::parse(&ln_address_api)?;
         let endpoint = safe_url.join(&format!("lnaddress/{}/{}", domain, username))?;
-        let http_client = reqwest::Client::new();
-        let result = http_client
+        let result = http::client()
             .get(endpoint.to_unsafe())
+            .timeout(http::QUICK)
             .send()
             .await
             .context("Failed to send GET request")?;
@@ -5401,9 +5405,11 @@ impl Multimint {
     ) -> anyhow::Result<Vec<FederationId>> {
         let endpoint = SafeUrl::parse(&recurringd_api)?.join("lnv1/federations")?;
 
-        let http_client = reqwest::Client::new();
-        let result = http_client
+        // `check_ln_address_availability` calls this before its own request, so
+        // the two share one user-visible wait — keep both on the short budget.
+        let result = http::client()
             .get(endpoint.to_unsafe())
+            .timeout(http::QUICK)
             .send()
             .await
             .context("Failed to send domains request")?;
@@ -5526,7 +5532,7 @@ impl Multimint {
                     };
 
                     if let Some(pk) = recipient_pk {
-                        let http_client = reqwest::Client::new();
+                        let http_client = http::client();
                         let update_url = match config.ln_address_api.join("lnaddress/update-pk") {
                             Ok(url) => url,
                             Err(_) => continue,

--- a/rust/ecashapp/src/nostr.rs
+++ b/rust/ecashapp/src/nostr.rs
@@ -74,6 +74,13 @@ const FEDERATION_OBSERVER_URL: &str = "https://observer.fedimint.org";
 
 pub const NWC_SUPPORTED_METHODS: &[&str] = &["get_info", "get_balance", "pay_invoice"];
 
+/// How long a single NWC relay connection attempt may take before the listener
+/// reports it and backs off. Without a bound here a dead relay leaves NWC
+/// silently non-functional for the lifetime of the process.
+const NWC_RELAY_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+const NWC_RELAY_BACKOFF_START: Duration = Duration::from_secs(5);
+const NWC_RELAY_BACKOFF_MAX: Duration = Duration::from_secs(300);
+
 #[derive(Debug, Deserialize)]
 #[serde(tag = "method", content = "params")]
 pub enum WalletConnectRequest {
@@ -374,11 +381,27 @@ impl NostrClient {
 
         let status = relay.status();
         info_to_flutter(format!("Relay connection status: {status:?}")).await;
-        relay.connect();
         info_to_flutter("Waiting for connection to relay...").await;
-        relay
-            .wait_for_connection(Duration::from_secs(u64::MAX))
+
+        // Keep retrying so a transient relay outage still self-heals, but with
+        // a bounded wait per attempt so an unreachable relay is reported rather
+        // than leaving NWC silently dead forever.
+        let mut backoff = NWC_RELAY_BACKOFF_START;
+        loop {
+            relay.connect();
+            relay.wait_for_connection(NWC_RELAY_CONNECT_TIMEOUT).await;
+            if matches!(relay.status(), nostr_sdk::RelayStatus::Connected) {
+                break;
+            }
+            error_to_flutter(format!(
+                "NWC relay {} unreachable, retrying in {}s",
+                nwc_config.relay,
+                backoff.as_secs()
+            ))
             .await;
+            tokio::time::sleep(backoff).await;
+            backoff = (backoff * 2).min(NWC_RELAY_BACKOFF_MAX);
+        }
         info_to_flutter("Connected to relay!").await;
 
         let filter = nostr_sdk::Filter::new().kind(nostr_sdk::Kind::WalletConnectRequest);

--- a/rust/ecashapp/src/nostr.rs
+++ b/rust/ecashapp/src/nostr.rs
@@ -13,7 +13,7 @@ use crate::{
         ContactSyncConfigKey, NostrRelaysKey, NostrRelaysKeyPrefix, NostrWalletConnectConfig,
         NostrWalletConnectKey, NostrWalletConnectKeyPrefix,
     },
-    error_to_flutter, federations, get_event_bus, info_to_flutter,
+    error_to_flutter, federations, get_event_bus, http, info_to_flutter,
     multimint::{
         ContactSyncEventKind, FederationSelector, LightningSendOutcome, MultimintEvent,
         NostrRecoveryPhase, RelayStatusKind,
@@ -691,12 +691,7 @@ impl NostrClient {
         }
 
         let url = format!("{FEDERATION_OBSERVER_URL}/api/federations");
-        let response = match reqwest::Client::new()
-            .get(&url)
-            .timeout(Duration::from_secs(10))
-            .send()
-            .await
-        {
+        let response = match http::client().get(&url).timeout(http::QUICK).send().await {
             Ok(response) => response,
             Err(e) => {
                 error_to_flutter(format!("Failed to reach fedimint observer: {e}")).await;
@@ -1096,11 +1091,7 @@ impl NostrClient {
         let url = format!("https://{}/.well-known/nostr.json?name={}", domain, name);
 
         // Make the HTTP request
-        let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(10))
-            .build()?;
-
-        let response = client.get(&url).send().await?;
+        let response = http::client().get(&url).timeout(http::QUICK).send().await?;
 
         if !response.status().is_success() {
             bail!("NIP-05 verification failed: HTTP {}", response.status());

--- a/rust/ecashapp/src/wallet/mod.rs
+++ b/rust/ecashapp/src/wallet/mod.rs
@@ -29,7 +29,7 @@ use crate::{
     app_error::{classify_anyhow, EcashAppError, EcashAppResult},
     db::{WalletV2PendingDepositFederationPrefix, WalletV2PendingDepositKey},
     event_bus::EventBus,
-    get_event_bus, info_to_flutter,
+    get_event_bus, http, info_to_flutter,
     multimint::{
         AwaitingConfsEvent, ClaimedEvent, ConfirmedEvent, DepositEventKind, MempoolEvent,
         MultimintEvent, OnChainWithdrawalMeta, WithdrawFees, WithdrawFeesResponse,
@@ -556,17 +556,21 @@ impl WalletHandler {
         let wallet_module = client.get_first_module::<WalletV2Module>()?;
         let network = wallet_module.get_network();
         let api_url = mempool_api_url(network);
-        let http = reqwest::Client::new();
+        let http_client = http::client();
 
         info_to_flutter(format!(
             "watch_v2_pegin_address: polling {api_url} for deposit to {address} (network {network})"
         ))
         .await;
 
+        // The shared client's timeout is what keeps this loop alive: `retry`
+        // only advances its backoff when the closure returns `Err`, so an
+        // untimed request hung on a half-open socket would stop the poller for
+        // good rather than retrying.
         let (txid, value) = fedimint_core::util::retry(
             "discover walletv2 deposit",
             fedimint_core::util::backoff_util::background_backoff(),
-            || async { discover_deposit(&http, &api_url, &address).await },
+            || async { discover_deposit(http_client, &api_url, &address).await },
         )
         .await
         .expect("Never gives up");
@@ -1144,13 +1148,13 @@ where
         .await;
 
     let api_url = mempool_api_url(network);
-    let http = reqwest::Client::new();
+    let http_client = http::client();
 
     let tx_height = fedimint_core::util::retry(
         "get confirmed block height",
         fedimint_core::util::backoff_util::background_backoff(),
         || async {
-            let resp = http
+            let resp = http_client
                 .get(format!("{}/tx/{}", api_url, txid))
                 .send()
                 .await?


### PR DESCRIPTION
- Adds a HTTP client with a shared connection pool
- Bounds all rust HTTP calls to a timeout of either 10, 15, or 30s
- Bounds NWC relay connection wait
- Fixes issue with federation backup not working because of stalled BTC price HTTP call