### PR TITLE
chore: bump to v0.11.0-alpha and add v0.10 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.10.0]
+
+- Guardian dashboard - federation health, audit, backup, and Lightning Gateway membership
+- Federation meta module support
+- Max button when sending over Lightning and LNURL
+- Nostr Wallet Connect hardening - client authorization gate, daily budget, and max invoice cap
+- PIN hardening - PIN is now salted and key-derived, attempts are throttled, and the PIN is required to view your mnemonic
+- Confirmation prompt before contacting an LNURL-withdraw server
+- Validation of scanned QR code input
+- Transaction id and fee shown for pending on-chain receives
+- Balance is shown when leaving a federation
+- Recovery now tells you when no backup was found on Nostr
+- Invoice expiration picker
+- Thousands separator for fiat amounts
+- Timeouts on network calls
+- Ecash from a Mint V2 federation you have not joined now offers to join and redeem
+
 ## [0.9.0]
 
 - Wallet V2 Module Support

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ecashapp
 description: "A Fedimint Wallet"
 publish_to: 'none'
-version: 0.10.0-alpha
+version: 0.11.0-alpha
 
 environment:
   sdk: ^3.7.2

--- a/rust/ecashapp/Cargo.lock
+++ b/rust/ecashapp/Cargo.lock
@@ -1521,7 +1521,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecashapp"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "anyhow",
  "argon2",

--- a/rust/ecashapp/Cargo.toml
+++ b/rust/ecashapp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecashapp"
-version = "0.10.0-alpha"
+version = "0.11.0-alpha"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
Bumping the version to `v0.11.0-alpha` and adding `v0.10` changelog