### PR TITLE
ci: cache Rust build in checks.yml, fix pre-commit format glob

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -47,6 +47,22 @@ jobs:
         with:
           components: rustfmt, clippy
 
+      # This is the gate every pull request waits on, and it had no cache at
+      # all: fmt, clippy and test each ran against a cold target directory, so
+      # the job rebuilt all ~500 dependencies — RocksDB and aws-lc-sys from
+      # source included — for the 21-23 minutes it took.
+      #
+      # `workspaces` has to name the crate directory. There is no workspace at
+      # the repo root, and the steps below `cd rust/ecashapp` with no
+      # --target-dir, so Cargo writes to `rust/ecashapp/target`.
+      #
+      # After the toolchain install on purpose: the cache key includes the rustc
+      # version.
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust/ecashapp
+
       - name: Check Rust formatting
         working-directory: rust/ecashapp
         run: cargo fmt --check

--- a/scripts/git-hooks/pre-commit.sh
+++ b/scripts/git-hooks/pre-commit.sh
@@ -2,13 +2,18 @@
 
 set -eo pipefail
 
-dart format -o none --set-exit-if-changed lib/**/*.dart > /dev/null \
+# Pass the directory, not a glob. `**` only works with `shopt -s globstar`,
+# which bash 3.2 — what macOS ships — does not have, so `lib/**/*.dart`
+# degraded to `lib/*/*.dart` and skipped all 50 top-level files (app.dart,
+# scan.dart, utils.dart, nwc.dart …) plus anything nested three deep. This is
+# also exactly what CI runs.
+dart format -o none --set-exit-if-changed lib/ > /dev/null \
   || {
        echo >&2 "
 ✖  Dart files aren’t formatted!
 Please run:
 
-    dart format lib/**/*.dart
+    dart format lib/
 
 and then try committing again.
 ";


### PR DESCRIPTION
Two CI guardrail fixes.

`checks.yml` is the PR gate (`cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test`) but has no Rust cache, so it recompiles ~500 crates including RocksDB and aws-lc-sys from scratch on every run — 21-23 minutes. Adds `Swatinem/rust-cache@v2` after the toolchain install, matching what `.github/actions/android-build/action.yml` and `macos-release.yml` already do. `workspaces: rust/ecashapp` is required because there is no cargo workspace at the repo root.

The pre-commit hook ran `dart format` over `lib/**/*.dart`. `**` is only recursive with `shopt -s globstar`, and macOS ships bash 3.2 which has no globstar at all, so it silently degraded to `lib/*/*.dart`: 44 of 97 files checked, and **zero** top-level ones — `lib/app.dart`, `lib/scan.dart`, `lib/utils.dart`, `lib/nwc.dart` are among the 53 skipped. Formatting failures in the largest hand-written files only showed up in CI ~22 minutes later. Now passes `lib/`, which is exactly what CI runs. The error message told users to run the same broken glob; fixed to `dart format lib/`.

Verified the hook rejects a misformat introduced in `lib/app.dart` (old command exit 0, new hook exit 1) and that `dart format --set-exit-if-changed lib/` passes on a clean tree.