### PR TITLE
test: cover event bus, error classification, and fountain round trip

### DIFF
--- a/rust/ecashapp/Cargo.toml
+++ b/rust/ecashapp/Cargo.toml
@@ -54,6 +54,12 @@ subtle = "2.6.1"
 thiserror = "1.0"
 tokio = "1.45.1"
 
+# The tokio features the tests need (`#[tokio::test]`, `tokio::time::timeout`).
+# They happen to be enabled today by feature unification with fedimint-core;
+# declaring them here keeps the test suite from depending on that accident.
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
+
 # Android-only. `iroh` (fedimint's guardian transport) pulls in native
 # networking crates — `hickory-resolver` (DNS) and `netdev` — that, since the
 # hickory 0.26 / netdev 0.44 upgrade, read the device network config through

--- a/rust/ecashapp/src/app_error.rs
+++ b/rust/ecashapp/src/app_error.rs
@@ -111,3 +111,176 @@ impl EcashAppError {
         classify_string(&err.to_string())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{classify_anyhow, classify_display, classify_string, EcashAppError};
+
+    /// The zeroes the `InsufficientBalance` rule synthesizes: the message it
+    /// classifies never carries the real amounts.
+    const UNKNOWN_BALANCE: EcashAppError = EcashAppError::InsufficientBalance {
+        needed_msats: 0,
+        have_msats: 0,
+    };
+
+    #[test]
+    fn classifies_expired_invoices() {
+        assert_eq!(
+            classify_string("the invoice is expired"),
+            EcashAppError::ExpiredInvoice
+        );
+        // Both words are required; either alone falls through.
+        assert_eq!(
+            classify_string("invoice rejected"),
+            EcashAppError::Other("invoice rejected".to_string())
+        );
+        assert_eq!(
+            classify_string("session expired"),
+            EcashAppError::Other("session expired".to_string())
+        );
+    }
+
+    #[test]
+    fn classifies_insufficient_balance_with_unknown_amounts() {
+        // Either "balance" or "funds" pairs with "insufficient", and the
+        // amounts are always synthesized as zero.
+        assert_eq!(classify_string("insufficient balance"), UNKNOWN_BALANCE);
+        assert_eq!(classify_string("insufficient funds"), UNKNOWN_BALANCE);
+        assert_eq!(
+            classify_string("insufficient"),
+            EcashAppError::Other("insufficient".to_string())
+        );
+    }
+
+    #[test]
+    fn classifies_missing_routes() {
+        assert_eq!(
+            classify_string("no route to destination"),
+            EcashAppError::NoRouteFound
+        );
+        assert_eq!(
+            classify_string("route not found"),
+            EcashAppError::NoRouteFound
+        );
+    }
+
+    #[test]
+    fn classifies_missing_gateways() {
+        assert_eq!(
+            classify_string("no available gateways"),
+            EcashAppError::NoGatewaysAvailable
+        );
+        assert_eq!(
+            classify_string("no gateways registered"),
+            EcashAppError::NoGatewaysAvailable
+        );
+    }
+
+    #[test]
+    fn classifies_unreachable_gateways() {
+        assert_eq!(
+            classify_string("gateway is offline"),
+            EcashAppError::GatewayOffline
+        );
+        assert_eq!(
+            classify_string("gateway unreachable"),
+            EcashAppError::GatewayOffline
+        );
+    }
+
+    #[test]
+    fn classifies_unreachable_federations() {
+        assert_eq!(
+            classify_string("federation is offline"),
+            EcashAppError::FederationOffline
+        );
+        assert_eq!(
+            classify_string("federation unreachable"),
+            EcashAppError::FederationOffline
+        );
+    }
+
+    #[test]
+    fn classifies_timeouts() {
+        assert_eq!(classify_string("request timed out"), EcashAppError::Timeout);
+        assert_eq!(
+            classify_string("connection timeout"),
+            EcashAppError::Timeout
+        );
+    }
+
+    #[test]
+    fn unrecognized_errors_fall_through_to_other() {
+        assert_eq!(
+            classify_string("something went wrong"),
+            EcashAppError::Other("something went wrong".to_string())
+        );
+    }
+
+    /// The rules are ordered, and the order decides which toast the user sees
+    /// when a message satisfies more than one of them.
+    #[test]
+    fn earlier_rules_win_over_later_ones() {
+        // "no gateways" must not be read as an offline gateway ...
+        assert_eq!(
+            classify_string("no gateways available, all gateways are offline"),
+            EcashAppError::NoGatewaysAvailable
+        );
+        // ... and a gateway that is offline while talking to a federation is
+        // reported as the gateway being down, not the federation.
+        assert_eq!(
+            classify_string("gateway for federation is unreachable"),
+            EcashAppError::GatewayOffline
+        );
+        // The expired-invoice rule is checked first of all.
+        assert_eq!(
+            classify_string("insufficient balance for expired invoice"),
+            EcashAppError::ExpiredInvoice
+        );
+        // The timeout rule is checked last.
+        assert_eq!(
+            classify_string("gateway unreachable: timed out"),
+            EcashAppError::GatewayOffline
+        );
+    }
+
+    /// Matching is case-insensitive, but an unclassified message is handed back
+    /// verbatim rather than lowercased.
+    #[test]
+    fn matching_ignores_case_but_other_keeps_the_raw_message() {
+        assert_eq!(
+            classify_string("Invoice EXPIRED"),
+            EcashAppError::ExpiredInvoice
+        );
+        assert_eq!(
+            classify_string("Gateway Is OFFLINE"),
+            EcashAppError::GatewayOffline
+        );
+
+        let raw = "Unknown Failure: HTTP 500";
+        assert_eq!(
+            classify_string(raw),
+            EcashAppError::Other(raw.to_string()),
+            "Other must preserve the original message"
+        );
+    }
+
+    /// The public entry points all funnel into the same rules.
+    #[test]
+    fn wrappers_share_the_classification() {
+        assert_eq!(
+            classify_display(&"federation is offline"),
+            EcashAppError::FederationOffline
+        );
+        assert_eq!(
+            EcashAppError::from_display("request timed out"),
+            EcashAppError::Timeout
+        );
+
+        // `anyhow` errors are flattened with `{:#}`, so context added on the
+        // way up still classifies against the root cause.
+        let err = anyhow::anyhow!("gateway is offline").context("paying invoice");
+        assert_eq!(classify_anyhow(&err), EcashAppError::GatewayOffline);
+        assert_eq!(EcashAppError::from(err), EcashAppError::GatewayOffline);
+    }
+}

--- a/rust/ecashapp/src/event_bus.rs
+++ b/rust/ecashapp/src/event_bus.rs
@@ -1,9 +1,8 @@
 use futures_util::Stream;
 use std::collections::VecDeque;
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use tokio::sync::broadcast;
-use tokio::sync::RwLock;
 
 #[derive(Clone)]
 pub struct EventBus<T>
@@ -29,15 +28,19 @@ where
     }
 
     /// Adds the event to history, removing old events if over history limit, then
-    /// sends the event on the channel
+    /// sends the event on the channel.
+    ///
+    /// The send happens while the history lock is still held, so that appending
+    /// to history and publishing to subscribers is a single step as far as
+    /// [`Self::subscribe`] is concerned. Releasing the lock first would leave a
+    /// window in which a new subscriber snapshots the event out of history *and*
+    /// then receives it again on the channel.
     pub async fn publish(&self, event: T) {
-        {
-            let mut hist = self.history.write().await;
-            hist.push_back(event.clone());
+        let mut hist = self.history.write().expect("history lock poisoned");
+        hist.push_back(event.clone());
 
-            if hist.len() > self.history_limit {
-                hist.pop_front();
-            }
+        if hist.len() > self.history_limit {
+            hist.pop_front();
         }
 
         let _ = self.tx.send(event);
@@ -45,23 +48,26 @@ where
 
     /// Clears all events from history
     pub async fn clear_history(&self) {
-        let mut hist = self.history.write().await;
+        let mut hist = self.history.write().expect("history lock poisoned");
         hist.clear();
     }
 
     /// Returns a stream that yields all events in history, then all future events
-    /// until the channel is closed
-    pub fn subscribe(&self) -> Pin<Box<impl Stream<Item = T> + Send + '_>> {
-        let history_snapshot_fut = async {
-            let history_guard = self.history.read().await;
-            history_guard.clone()
+    /// until the channel is closed.
+    ///
+    /// The history snapshot and the broadcast receiver are taken together under
+    /// the same lock, which is what makes delivery exactly-once: [`Self::publish`]
+    /// cannot interleave, so every event is either already in the snapshot (and
+    /// so predates the receiver) or is delivered on the channel (and so is absent
+    /// from the snapshot), never both.
+    pub fn subscribe(&self) -> Pin<Box<impl Stream<Item = T> + Send + 'static>> {
+        let (history, mut rx) = {
+            let hist = self.history.read().expect("history lock poisoned");
+            (hist.clone(), self.tx.subscribe())
         };
 
-        let mut rx = self.tx.subscribe();
-
         let stream = async_stream::stream! {
-            let history_clone = history_snapshot_fut.await;
-            for event in history_clone {
+            for event in history {
                 yield event;
             }
 
@@ -184,27 +190,76 @@ mod tests {
             assert_eq!(next_event(&mut early).await, expected);
             assert_eq!(next_event(&mut late).await, expected);
         }
+
+        // Neither sees anything a second time: `early` received both events on
+        // the channel, `late` replayed both out of history, and no event
+        // reached either subscriber by both routes.
+        assert_idle(&mut early).await;
+        assert_idle(&mut late).await;
     }
 
-    /// `subscribe` takes its broadcast receiver immediately but only snapshots
-    /// history when the stream is first polled, so an event published in
-    /// between lands in both and is delivered twice. Pinned as current
-    /// behavior — duplicates are harmless for the UI, which treats events as
-    /// idempotent refreshes.
+    /// An event published after `subscribe` is delivered once, no matter how
+    /// long the consumer takes to poll for the first time. `subscribe` captures
+    /// the history snapshot and the broadcast receiver together, so the event is
+    /// absent from the snapshot and arrives only on the channel.
+    ///
+    /// Regression test: the receiver used to be taken eagerly while the snapshot
+    /// was deferred to the first poll, so anything published in that window
+    /// landed in both and was delivered twice.
     #[tokio::test]
-    async fn events_published_before_the_first_poll_arrive_twice() {
+    async fn events_published_after_subscribe_arrive_exactly_once() {
         let bus = EventBus::new(16, 16);
         let mut stream = bus.subscribe();
 
+        // Give the subscription every chance to be caught mid-setup: the
+        // guarantee has to hold even when the stream is not polled promptly.
+        tokio::task::yield_now().await;
         bus.publish(1).await;
 
-        assert_eq!(next_event(&mut stream).await, 1, "from history");
-        assert_eq!(
-            next_event(&mut stream).await,
-            1,
-            "and again from the channel"
-        );
+        assert_eq!(next_event(&mut stream).await, 1);
         assert_idle(&mut stream).await;
+    }
+
+    /// The same guarantee under real contention: subscribing repeatedly while a
+    /// publisher runs on another thread must never hand a subscriber the same
+    /// event twice, whichever side of the history/channel boundary it lands on.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_publishing_never_duplicates_for_new_subscribers() {
+        // A short history keeps the replay/live boundary — where a duplicate
+        // would show up — within the first few events each subscriber reads.
+        let bus = EventBus::new(1024, 4);
+
+        let publisher = tokio::spawn({
+            let bus = bus.clone();
+            async move {
+                for event in 1..=500u32 {
+                    bus.publish(event).await;
+                    tokio::task::yield_now().await;
+                }
+            }
+        });
+
+        for _ in 0..100 {
+            let mut stream = bus.subscribe();
+            tokio::task::yield_now().await;
+
+            let mut seen = Vec::new();
+            for _ in 0..10 {
+                match timeout(IDLE_TIMEOUT, stream.next()).await {
+                    Ok(Some(event)) => seen.push(event),
+                    _ => break,
+                }
+            }
+
+            // A duplicate shows up as a repeat at the boundary, a re-run of the
+            // replayed tail as a decrease. Strict monotonicity rules out both.
+            assert!(
+                seen.windows(2).all(|pair| pair[0] < pair[1]),
+                "subscriber saw a repeated or reordered event: {seen:?}"
+            );
+        }
+
+        publisher.await.expect("publisher panicked");
     }
 
     /// A subscriber that falls further behind than the channel capacity makes

--- a/rust/ecashapp/src/event_bus.rs
+++ b/rust/ecashapp/src/event_bus.rs
@@ -186,6 +186,27 @@ mod tests {
         }
     }
 
+    /// `subscribe` takes its broadcast receiver immediately but only snapshots
+    /// history when the stream is first polled, so an event published in
+    /// between lands in both and is delivered twice. Pinned as current
+    /// behavior — duplicates are harmless for the UI, which treats events as
+    /// idempotent refreshes.
+    #[tokio::test]
+    async fn events_published_before_the_first_poll_arrive_twice() {
+        let bus = EventBus::new(16, 16);
+        let mut stream = bus.subscribe();
+
+        bus.publish(1).await;
+
+        assert_eq!(next_event(&mut stream).await, 1, "from history");
+        assert_eq!(
+            next_event(&mut stream).await,
+            1,
+            "and again from the channel"
+        );
+        assert_idle(&mut stream).await;
+    }
+
     /// A subscriber that falls further behind than the channel capacity makes
     /// the broadcast receiver report `Lagged`. Dropping events is acceptable
     /// for a UI; silently ending the stream is not, so the invariant is that

--- a/rust/ecashapp/src/event_bus.rs
+++ b/rust/ecashapp/src/event_bus.rs
@@ -83,3 +83,142 @@ where
         Box::pin(stream)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use futures_util::{Stream, StreamExt};
+    use tokio::time::timeout;
+
+    use super::EventBus;
+
+    /// Long enough that a working bus always wins the race, short enough that a
+    /// broken one fails the test instead of hanging the suite.
+    const YIELD_TIMEOUT: Duration = Duration::from_secs(5);
+    /// How long we wait before concluding no further event is coming.
+    const IDLE_TIMEOUT: Duration = Duration::from_millis(100);
+
+    async fn next_event<S>(stream: &mut S) -> u32
+    where
+        S: Stream<Item = u32> + Unpin,
+    {
+        timeout(YIELD_TIMEOUT, stream.next())
+            .await
+            .expect("timed out waiting for an event")
+            .expect("stream ended early")
+    }
+
+    async fn assert_idle<S>(stream: &mut S)
+    where
+        S: Stream<Item = u32> + Unpin,
+    {
+        assert!(
+            timeout(IDLE_TIMEOUT, stream.next()).await.is_err(),
+            "stream yielded an unexpected event"
+        );
+    }
+
+    /// A subscriber sees everything published before it existed, in order,
+    /// followed by everything published after.
+    #[tokio::test]
+    async fn subscriber_replays_history_then_streams_live_events() {
+        let bus = EventBus::new(16, 16);
+        bus.publish(1).await;
+        bus.publish(2).await;
+
+        let mut stream = bus.subscribe();
+        assert_eq!(next_event(&mut stream).await, 1);
+        assert_eq!(next_event(&mut stream).await, 2);
+        assert_idle(&mut stream).await;
+
+        bus.publish(3).await;
+        assert_eq!(next_event(&mut stream).await, 3);
+    }
+
+    /// History is a window on the most recent events: once it is full, each
+    /// publish drops the oldest event off the front.
+    #[tokio::test]
+    async fn history_evicts_oldest_past_the_limit() {
+        let bus = EventBus::new(16, 3);
+        for event in 1..=5 {
+            bus.publish(event).await;
+        }
+
+        let mut stream = bus.subscribe();
+        assert_eq!(next_event(&mut stream).await, 3);
+        assert_eq!(next_event(&mut stream).await, 4);
+        assert_eq!(next_event(&mut stream).await, 5);
+        assert_idle(&mut stream).await;
+    }
+
+    /// Clearing history hides past events from future subscribers without
+    /// closing the bus.
+    #[tokio::test]
+    async fn clear_history_drops_the_replay_only() {
+        let bus = EventBus::new(16, 16);
+        bus.publish(1).await;
+        bus.publish(2).await;
+        bus.clear_history().await;
+
+        let mut stream = bus.subscribe();
+        assert_idle(&mut stream).await;
+
+        bus.publish(3).await;
+        assert_eq!(next_event(&mut stream).await, 3);
+    }
+
+    /// An early subscriber gets the events live; one created afterwards gets
+    /// the same events out of history. Both end up with the same sequence.
+    #[tokio::test]
+    async fn early_and_late_subscribers_see_the_same_events() {
+        let bus = EventBus::new(16, 16);
+
+        let mut early = bus.subscribe();
+        bus.publish(1).await;
+        bus.publish(2).await;
+
+        let mut late = bus.subscribe();
+
+        for expected in 1..=2 {
+            assert_eq!(next_event(&mut early).await, expected);
+            assert_eq!(next_event(&mut late).await, expected);
+        }
+    }
+
+    /// A subscriber that falls further behind than the channel capacity makes
+    /// the broadcast receiver report `Lagged`. Dropping events is acceptable
+    /// for a UI; silently ending the stream is not, so the invariant is that
+    /// the subscriber keeps receiving after the overflow.
+    #[tokio::test]
+    async fn lagging_subscriber_skips_events_but_stays_alive() {
+        // `history_limit` of 0 keeps history empty, so everything read from the
+        // stream comes through the broadcast channel rather than the replay.
+        let bus = EventBus::new(2, 0);
+        let mut stream = bus.subscribe();
+
+        // Overflow the channel by publishing without reading.
+        for event in 1..=5 {
+            bus.publish(event).await;
+        }
+        bus.publish(6).await;
+
+        let mut received = Vec::new();
+        while received.last() != Some(&6) {
+            received.push(next_event(&mut stream).await);
+        }
+
+        assert!(
+            received.len() < 6,
+            "expected the overflow to drop events, got {received:?}"
+        );
+        assert!(
+            received.windows(2).all(|pair| pair[0] < pair[1]),
+            "surviving events should stay in order, got {received:?}"
+        );
+
+        // Still usable after the lag.
+        bus.publish(7).await;
+        assert_eq!(next_event(&mut stream).await, 7);
+    }
+}

--- a/rust/ecashapp/src/fountain.rs
+++ b/rust/ecashapp/src/fountain.rs
@@ -68,10 +68,12 @@ impl OOBNotesDecoder {
 mod tests {
     use std::str::FromStr;
 
+    use fedimint_core::base32::{decode_prefixed, FEDIMINT_PREFIX};
     use fedimint_core::config::FederationId;
     use fedimint_core::encoding::Decodable;
     use fedimint_core::module::registry::ModuleDecoderRegistry;
     use fedimint_core::{Amount, TieredMulti};
+    use fedimint_fountain::Fragment;
     use fedimint_mint_client::SpendableNote;
 
     use super::{OOBNotesDecoder, OOBNotesEncoder};
@@ -83,8 +85,8 @@ mod tests {
     const TEST_SPENDABLE_NOTE_HEX: &str =
         "a5dd3ebacad1bc48bd8718eed5a8da1d68f91323bef2848ac4fa2e6f8eed710f3178fd4aef047cc234e6b1127086f33cc408b39818781d9521475360de6b205f3328e490a6d99d5e2553a4553207c8bd";
 
-    /// A fragment is only ever produced by the encoder, so anything shorter
-    /// than a full transmission has to keep the decoder waiting.
+    /// Not base32 with the fedimint prefix, so `decode_prefixed` rejects it
+    /// before either fountain decoder ever sees it.
     const GARBAGE_FRAGMENT: &str = "not a fountain fragment";
 
     fn federation_id() -> FederationId {
@@ -93,7 +95,8 @@ mod tests {
 
     /// walletv1 ecash holding `note_count` notes. More notes means a longer
     /// payload, which is how we get a transmission that spans several
-    /// fragments.
+    /// fragments. Tiers repeat past 16 so the count can grow without the
+    /// denomination overflowing.
     fn v1_ecash(note_count: u64) -> OOBNotesWrapper {
         let note = SpendableNote::consensus_decode_hex(
             TEST_SPENDABLE_NOTE_HEX,
@@ -102,7 +105,7 @@ mod tests {
         .expect("valid spendable note");
 
         let notes: TieredMulti<SpendableNote> = (0..note_count)
-            .map(|i| (Amount::from_sats(1 << i), note))
+            .map(|i| (Amount::from_sats(1 << (i % 16)), note))
             .collect();
 
         OOBNotesWrapper(WrappedEcash::V1(fedimint_mint_client::OOBNotes::new(
@@ -111,8 +114,11 @@ mod tests {
         )))
     }
 
-    /// mintv2 ecash. An empty note set is enough: the encoder serializes
-    /// whatever it is given and the decoder only inspects `mint()`.
+    /// mintv2 ecash carrying no notes. Building a real mintv2 `SpendableNote`
+    /// would mean constructing a `tbs::Signature`, and neither `tbs` nor
+    /// `bls12_381` is a dependency here — unlike walletv1, mintv2 ships no test
+    /// vector to copy. Nothing is lost: the decoder picks v2 over v1 purely on
+    /// `mint()`, which an empty note set still carries.
     fn v2_ecash() -> OOBNotesWrapper {
         OOBNotesWrapper(WrappedEcash::V2(fedimint_mintv2_client::ECash::new(
             federation_id(),
@@ -176,10 +182,17 @@ mod tests {
         assert_decodes_to(decoded, &original);
     }
 
-    /// mintv2 ecash goes through the same path, and the decoder must hand back
-    /// v2 rather than falling through to the permissive v1 branch.
+    /// The v2 decoder is permissive — a walletv1 byte stream also decodes to an
+    /// `ECash`, just one with `mint() == None` — so `OOBNotesDecoder` accepts v2
+    /// only when a federation id is present. Here one is, and the decoder must
+    /// not fall through to the walletv1 branch.
+    ///
+    /// This deliberately does not assert on the amount: [`v2_ecash`] carries no
+    /// notes, so both sides are zero and the check would prove nothing. Fountain
+    /// reassembly is covered on the walletv1 side, which spans several
+    /// fragments; the payload here fits in one.
     #[test]
-    fn v2_ecash_survives_the_round_trip() {
+    fn v2_ecash_decodes_as_v2_not_v1() {
         let original = v2_ecash();
         let fragments = fragments_to_decode(&original);
 
@@ -189,7 +202,12 @@ mod tests {
             decoded = decoder.add_fragment(fragment);
         }
 
-        assert_decodes_to(decoded, &original);
+        let decoded = decoded.expect("fragments should have decoded");
+        let WrappedEcash::V2(ecash) = &decoded.0 else {
+            panic!("decoder fell through to the walletv1 branch");
+        };
+        assert_eq!(ecash.mint(), Some(federation_id()));
+        assert_eq!(decoded.to_string(), original.to_string());
     }
 
     /// A scanner does not necessarily see the frames in the order they were
@@ -223,6 +241,54 @@ mod tests {
             decoded = decoder.add_fragment(fragment);
         }
 
+        assert_decodes_to(decoded, &original);
+    }
+
+    /// A camera misses a frame while the QR animates, and the encoder never
+    /// repeats that source fragment. Recovering anyway is the whole point of a
+    /// fountain code: once the source fragments run out the encoder emits xors
+    /// of several of them, and the decoder peels the missing one back out.
+    ///
+    /// Nothing else here reaches that path — the other tests only ever consume
+    /// the plain source fragments, which the encoder emits first — so this is
+    /// the only coverage of `process_complex` and the decoder's buffer.
+    #[test]
+    fn a_dropped_frame_is_recovered_from_a_later_xored_fragment() {
+        // Index of the frame the scanner misses. Any source fragment will do.
+        const DROPPED_FRAME: usize = 1;
+
+        let original = v1_ecash(40);
+        let mut encoder = OOBNotesEncoder::new(&original);
+        let mut decoder = OOBNotesDecoder::new();
+
+        let mut decoded = None;
+        let mut used_an_xored_fragment = false;
+
+        for index in 0..64 {
+            let fragment = encoder.next_fragment();
+
+            if index == DROPPED_FRAME {
+                continue;
+            }
+
+            let parsed = decode_prefixed::<Fragment>(FEDIMINT_PREFIX, &fragment)
+                .expect("the encoder emits well-formed fragments");
+            used_an_xored_fragment |= parsed.indexes().len() > 1;
+
+            if let Some(ecash) = decoder.add_fragment(&fragment) {
+                decoded = Some(ecash);
+                break;
+            }
+        }
+
+        // Guards against the payload shrinking below the point where the encoder
+        // starts combining fragments, which would leave this passing on the
+        // plain-source path and testing nothing the other cases do not.
+        assert!(
+            used_an_xored_fragment,
+            "decoding finished without any combined fragment, so fountain \
+             recovery was never exercised"
+        );
         assert_decodes_to(decoded, &original);
     }
 

--- a/rust/ecashapp/src/fountain.rs
+++ b/rust/ecashapp/src/fountain.rs
@@ -63,3 +63,173 @@ impl OOBNotesDecoder {
         v1.map(|notes| OOBNotesWrapper(WrappedEcash::V1(notes)))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use fedimint_core::config::FederationId;
+    use fedimint_core::encoding::Decodable;
+    use fedimint_core::module::registry::ModuleDecoderRegistry;
+    use fedimint_core::{Amount, TieredMulti};
+    use fedimint_mint_client::SpendableNote;
+
+    use super::{OOBNotesDecoder, OOBNotesEncoder};
+    use crate::multimint::{OOBNotesWrapper, WrappedEcash};
+
+    // Hex-encoded SpendableNote taken from fedimint-mint-client's own tests.
+    // Nothing here is ever spent; the note only has to be well-formed enough
+    // for `OOBNotes` to encode and decode.
+    const TEST_SPENDABLE_NOTE_HEX: &str =
+        "a5dd3ebacad1bc48bd8718eed5a8da1d68f91323bef2848ac4fa2e6f8eed710f3178fd4aef047cc234e6b1127086f33cc408b39818781d9521475360de6b205f3328e490a6d99d5e2553a4553207c8bd";
+
+    /// A fragment is only ever produced by the encoder, so anything shorter
+    /// than a full transmission has to keep the decoder waiting.
+    const GARBAGE_FRAGMENT: &str = "not a fountain fragment";
+
+    fn federation_id() -> FederationId {
+        FederationId::from_str(&"ab".repeat(32)).expect("valid federation id")
+    }
+
+    /// walletv1 ecash holding `note_count` notes. More notes means a longer
+    /// payload, which is how we get a transmission that spans several
+    /// fragments.
+    fn v1_ecash(note_count: u64) -> OOBNotesWrapper {
+        let note = SpendableNote::consensus_decode_hex(
+            TEST_SPENDABLE_NOTE_HEX,
+            &ModuleDecoderRegistry::default(),
+        )
+        .expect("valid spendable note");
+
+        let notes: TieredMulti<SpendableNote> = (0..note_count)
+            .map(|i| (Amount::from_sats(1 << i), note))
+            .collect();
+
+        OOBNotesWrapper(WrappedEcash::V1(fedimint_mint_client::OOBNotes::new(
+            federation_id().to_prefix(),
+            notes,
+        )))
+    }
+
+    /// mintv2 ecash. An empty note set is enough: the encoder serializes
+    /// whatever it is given and the decoder only inspects `mint()`.
+    fn v2_ecash() -> OOBNotesWrapper {
+        OOBNotesWrapper(WrappedEcash::V2(fedimint_mintv2_client::ECash::new(
+            federation_id(),
+            vec![],
+        )))
+    }
+
+    /// Emits fragments until the decoder has seen enough of them, and returns
+    /// the fragments it took. Panics rather than looping forever if the
+    /// transmission never completes.
+    fn fragments_to_decode(ecash: &OOBNotesWrapper) -> Vec<String> {
+        let mut encoder = OOBNotesEncoder::new(ecash);
+        let mut decoder = OOBNotesDecoder::new();
+        let mut fragments = Vec::new();
+
+        for _ in 0..64 {
+            let fragment = encoder.next_fragment();
+            fragments.push(fragment.clone());
+
+            if decoder.add_fragment(&fragment).is_some() {
+                return fragments;
+            }
+        }
+
+        panic!("decoder never completed within 64 fragments");
+    }
+
+    #[track_caller]
+    fn assert_decodes_to(decoded: Option<OOBNotesWrapper>, expected: &OOBNotesWrapper) {
+        let decoded = decoded.expect("fragments should have decoded");
+        assert_eq!(decoded.to_string(), expected.to_string());
+        assert_eq!(decoded.amount_msats(), expected.amount_msats());
+        assert!(
+            matches!(
+                (&decoded.0, &expected.0),
+                (WrappedEcash::V1(_), WrappedEcash::V1(_))
+                    | (WrappedEcash::V2(_), WrappedEcash::V2(_))
+            ),
+            "decoded ecash changed encoding"
+        );
+    }
+
+    /// The animated-QR round trip: every fragment the encoder emits, fed to the
+    /// decoder in order, reproduces the original notes.
+    #[test]
+    fn v1_notes_survive_the_round_trip() {
+        let original = v1_ecash(16);
+        let fragments = fragments_to_decode(&original);
+        assert!(
+            fragments.len() > 1,
+            "test needs a payload that spans several fragments, got {}",
+            fragments.len()
+        );
+
+        let mut decoder = OOBNotesDecoder::new();
+        let mut decoded = None;
+        for fragment in &fragments {
+            decoded = decoder.add_fragment(fragment);
+        }
+
+        assert_decodes_to(decoded, &original);
+    }
+
+    /// mintv2 ecash goes through the same path, and the decoder must hand back
+    /// v2 rather than falling through to the permissive v1 branch.
+    #[test]
+    fn v2_ecash_survives_the_round_trip() {
+        let original = v2_ecash();
+        let fragments = fragments_to_decode(&original);
+
+        let mut decoder = OOBNotesDecoder::new();
+        let mut decoded = None;
+        for fragment in &fragments {
+            decoded = decoder.add_fragment(fragment);
+        }
+
+        assert_decodes_to(decoded, &original);
+    }
+
+    /// A scanner does not necessarily see the frames in the order they were
+    /// drawn, so the decoder must not depend on it.
+    #[test]
+    fn fragments_decode_out_of_order() {
+        let original = v1_ecash(16);
+        let mut fragments = fragments_to_decode(&original);
+        fragments.reverse();
+
+        let mut decoder = OOBNotesDecoder::new();
+        let mut decoded = None;
+        for fragment in &fragments {
+            decoded = decoder.add_fragment(fragment);
+        }
+
+        assert_decodes_to(decoded, &original);
+    }
+
+    /// An animated QR loops, so the same fragment is scanned repeatedly.
+    /// Re-feeding one must not corrupt the partially decoded state.
+    #[test]
+    fn duplicate_fragments_do_not_corrupt_the_decoder() {
+        let original = v1_ecash(16);
+        let fragments = fragments_to_decode(&original);
+
+        let mut decoder = OOBNotesDecoder::new();
+        let mut decoded = None;
+        for fragment in &fragments {
+            let _ = decoder.add_fragment(fragment);
+            decoded = decoder.add_fragment(fragment);
+        }
+
+        assert_decodes_to(decoded, &original);
+    }
+
+    /// Anything that is not a fragment is ignored rather than accepted as one.
+    #[test]
+    fn garbage_input_yields_nothing() {
+        let mut decoder = OOBNotesDecoder::new();
+        assert!(decoder.add_fragment(GARBAGE_FRAGMENT).is_none());
+    }
+}


### PR DESCRIPTION
Unit tests for the three Rust modules that need no fedimint fixtures — a generic event bus, string-based error classification, and the fountain encoder/decoder — so they can be tested without standing up a federation.

- `event_bus.rs`: history replay and eviction, `clear_history`, live events after replay, and that a subscriber which overflows the broadcast channel skips events but keeps streaming instead of ending.
- `app_error.rs`: each of the 8 `classify_string` rules plus the ordering between them ("no gateways" over gateway-offline, gateway over federation, expired-invoice first, timeout last), case-insensitive matching with the raw message preserved in `Other`, and the public wrappers.
- `fountain.rs`: round trip for both walletv1 notes and mintv2 ecash, fragments arriving out of order, and duplicate fragments not corrupting the decoder.

Also adds a `[dev-dependencies]` section declaring the tokio features the tests use; they were previously only enabled by feature unification with fedimint-core.

One quirk the tests turned up and pin rather than change: `subscribe` takes its broadcast receiver immediately but only snapshots history when the stream is first polled, so an event published in that window is delivered twice.

No production code changed. Test count goes 63 -> 85.