### PR TITLE
fix: remove getModuleIdForPaymentType and fix recovery with new modules

### DIFF
--- a/lib/frb_generated.dart
+++ b/lib/frb_generated.dart
@@ -440,7 +440,7 @@ abstract class RustLibApi extends BaseApi {
   Future<RecoveryProgress> crateMultimintMultimintGetRecoveryProgress({
     required Multimint that,
     required FederationId federationId,
-    required int moduleId,
+    required RecoveryModule recoveryModule,
   });
 
   Future<bool> crateMultimintMultimintGetShowMsats({required Multimint that});
@@ -1084,7 +1084,7 @@ abstract class RustLibApi extends BaseApi {
 
   Future<(int, int)> crateGetModuleRecoveryProgress({
     required FederationId federationId,
-    required int moduleId,
+    required RecoveryModule recoveryModule,
   });
 
   Future<List<(BigInt, BigInt)>> crateGetNoteSummary({
@@ -1353,7 +1353,7 @@ abstract class RustLibApi extends BaseApi {
 
   Stream<(int, int)> crateSubscribeRecoveryProgress({
     required FederationId federationId,
-    required int moduleId,
+    required RecoveryModule recoveryModule,
   });
 
   Future<void> crateSyncContacts({required String npub});
@@ -4443,7 +4443,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   Future<RecoveryProgress> crateMultimintMultimintGetRecoveryProgress({
     required Multimint that,
     required FederationId federationId,
-    required int moduleId,
+    required RecoveryModule recoveryModule,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -4457,7 +4457,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             federationId,
             serializer,
           );
-          sse_encode_u_16(moduleId, serializer);
+          sse_encode_recovery_module(recoveryModule, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -4471,7 +4471,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeErrorData: null,
         ),
         constMeta: kCrateMultimintMultimintGetRecoveryProgressConstMeta,
-        argValues: [that, federationId, moduleId],
+        argValues: [that, federationId, recoveryModule],
         apiImpl: this,
       ),
     );
@@ -4480,7 +4480,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TaskConstMeta get kCrateMultimintMultimintGetRecoveryProgressConstMeta =>
       const TaskConstMeta(
         debugName: "Multimint_get_recovery_progress",
-        argNames: ["that", "federationId", "moduleId"],
+        argNames: ["that", "federationId", "recoveryModule"],
       );
 
   @override
@@ -9531,7 +9531,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @override
   Future<(int, int)> crateGetModuleRecoveryProgress({
     required FederationId federationId,
-    required int moduleId,
+    required RecoveryModule recoveryModule,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -9541,7 +9541,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             federationId,
             serializer,
           );
-          sse_encode_u_16(moduleId, serializer);
+          sse_encode_recovery_module(recoveryModule, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -9554,7 +9554,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeErrorData: null,
         ),
         constMeta: kCrateGetModuleRecoveryProgressConstMeta,
-        argValues: [federationId, moduleId],
+        argValues: [federationId, recoveryModule],
         apiImpl: this,
       ),
     );
@@ -9563,7 +9563,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TaskConstMeta get kCrateGetModuleRecoveryProgressConstMeta =>
       const TaskConstMeta(
         debugName: "get_module_recovery_progress",
-        argNames: ["federationId", "moduleId"],
+        argNames: ["federationId", "recoveryModule"],
       );
 
   @override
@@ -11774,7 +11774,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @override
   Stream<(int, int)> crateSubscribeRecoveryProgress({
     required FederationId federationId,
-    required int moduleId,
+    required RecoveryModule recoveryModule,
   }) {
     final sink = RustStreamSink<(int, int)>();
     unawaited(
@@ -11787,7 +11787,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
               federationId,
               serializer,
             );
-            sse_encode_u_16(moduleId, serializer);
+            sse_encode_recovery_module(recoveryModule, serializer);
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
@@ -11800,7 +11800,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             decodeErrorData: null,
           ),
           constMeta: kCrateSubscribeRecoveryProgressConstMeta,
-          argValues: [sink, federationId, moduleId],
+          argValues: [sink, federationId, recoveryModule],
           apiImpl: this,
         ),
       ),
@@ -11811,7 +11811,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TaskConstMeta get kCrateSubscribeRecoveryProgressConstMeta =>
       const TaskConstMeta(
         debugName: "subscribe_recovery_progress",
-        argNames: ["sink", "federationId", "moduleId"],
+        argNames: ["sink", "federationId", "recoveryModule"],
       );
 
   @override
@@ -14057,7 +14057,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case 4:
         return MultimintEvent_RecoveryProgress(
           dco_decode_String(raw[1]),
-          dco_decode_u_16(raw[2]),
+          dco_decode_recovery_module(raw[2]),
           dco_decode_u_32(raw[3]),
           dco_decode_u_32(raw[4]),
         );
@@ -14688,6 +14688,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
     return (dco_decode_u_64(arr[0]), dco_decode_usize(arr[1]));
+  }
+
+  @protected
+  RecoveryModule dco_decode_recovery_module(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return RecoveryModule.values[raw as int];
   }
 
   @protected
@@ -17051,7 +17057,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         return MultimintEvent_RecoveryDone(var_field0);
       case 4:
         var var_field0 = sse_decode_String(deserializer);
-        var var_field1 = sse_decode_u_16(deserializer);
+        var var_field1 = sse_decode_recovery_module(deserializer);
         var var_field2 = sse_decode_u_32(deserializer);
         var var_field3 = sse_decode_u_32(deserializer);
         return MultimintEvent_RecoveryProgress(
@@ -17722,6 +17728,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_field0 = sse_decode_u_64(deserializer);
     var var_field1 = sse_decode_usize(deserializer);
     return (var_field0, var_field1);
+  }
+
+  @protected
+  RecoveryModule sse_decode_recovery_module(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var inner = sse_decode_i_32(deserializer);
+    return RecoveryModule.values[inner];
   }
 
   @protected
@@ -20135,7 +20148,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       ):
         sse_encode_i_32(4, serializer);
         sse_encode_String(field0, serializer);
-        sse_encode_u_16(field1, serializer);
+        sse_encode_recovery_module(field1, serializer);
         sse_encode_u_32(field2, serializer);
         sse_encode_u_32(field3, serializer);
       case MultimintEvent_Ecash(field0: final field0):
@@ -20772,6 +20785,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_u_64(self.$1, serializer);
     sse_encode_usize(self.$2, serializer);
+  }
+
+  @protected
+  void sse_encode_recovery_module(
+    RecoveryModule self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.index, serializer);
   }
 
   @protected
@@ -21897,11 +21919,11 @@ class MultimintImpl extends RustOpaque implements Multimint {
 
   Future<RecoveryProgress> getRecoveryProgress({
     required FederationId federationId,
-    required int moduleId,
+    required RecoveryModule recoveryModule,
   }) => RustLib.instance.api.crateMultimintMultimintGetRecoveryProgress(
     that: this,
     federationId: federationId,
-    moduleId: moduleId,
+    recoveryModule: recoveryModule,
   );
 
   Future<bool> getShowMsats() =>

--- a/lib/frb_generated.io.dart
+++ b/lib/frb_generated.io.dart
@@ -1180,6 +1180,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   (BigInt, BigInt) dco_decode_record_u_64_usize(dynamic raw);
 
   @protected
+  RecoveryModule dco_decode_recovery_module(dynamic raw);
+
+  @protected
   ReissueFees dco_decode_reissue_fees(dynamic raw);
 
   @protected
@@ -2317,6 +2320,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   (BigInt, BigInt) sse_decode_record_u_64_usize(SseDeserializer deserializer);
+
+  @protected
+  RecoveryModule sse_decode_recovery_module(SseDeserializer deserializer);
 
   @protected
   ReissueFees sse_decode_reissue_fees(SseDeserializer deserializer);
@@ -3678,6 +3684,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_record_u_64_usize(
     (BigInt, BigInt) self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_recovery_module(
+    RecoveryModule self,
     SseSerializer serializer,
   );
 

--- a/lib/frb_generated.web.dart
+++ b/lib/frb_generated.web.dart
@@ -1182,6 +1182,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   (BigInt, BigInt) dco_decode_record_u_64_usize(dynamic raw);
 
   @protected
+  RecoveryModule dco_decode_recovery_module(dynamic raw);
+
+  @protected
   ReissueFees dco_decode_reissue_fees(dynamic raw);
 
   @protected
@@ -2319,6 +2322,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   (BigInt, BigInt) sse_decode_record_u_64_usize(SseDeserializer deserializer);
+
+  @protected
+  RecoveryModule sse_decode_recovery_module(SseDeserializer deserializer);
 
   @protected
   ReissueFees sse_decode_reissue_fees(SseDeserializer deserializer);
@@ -3680,6 +3686,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_record_u_64_usize(
     (BigInt, BigInt) self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_recovery_module(
+    RecoveryModule self,
     SseSerializer serializer,
   );
 

--- a/lib/lib.dart
+++ b/lib/lib.dart
@@ -411,18 +411,18 @@ Future<BigInt> getMaxWithdrawableAmount({
 
 Future<(int, int)> getModuleRecoveryProgress({
   required FederationId federationId,
-  required int moduleId,
+  required RecoveryModule recoveryModule,
 }) => RustLib.instance.api.crateGetModuleRecoveryProgress(
   federationId: federationId,
-  moduleId: moduleId,
+  recoveryModule: recoveryModule,
 );
 
 Stream<(int, int)> subscribeRecoveryProgress({
   required FederationId federationId,
-  required int moduleId,
+  required RecoveryModule recoveryModule,
 }) => RustLib.instance.api.crateSubscribeRecoveryProgress(
   federationId: federationId,
-  moduleId: moduleId,
+  recoveryModule: recoveryModule,
 );
 
 Future<(ParsedText, FederationSelector)> parseScannedTextForFederation({

--- a/lib/models.dart
+++ b/lib/models.dart
@@ -1,2 +1,19 @@
+import 'package:ecashapp/multimint.dart';
+
 /// Defines the available payment methods in the app
 enum PaymentType { lightning, onchain, ecash }
+
+extension PaymentTypeRecovery on PaymentType {
+  /// The recovery bar this payment type reads.
+  ///
+  /// Deliberately not a module instance id: guardians assign those by
+  /// enumerating the federation's *enabled* modules alphabetically by kind, so
+  /// the same payment type sits at a different id on a v2-only federation than
+  /// on a legacy one. Rust resolves the ids from the client config and
+  /// aggregates across the modules behind one bar.
+  RecoveryModule get recoveryModule => switch (this) {
+    PaymentType.lightning => RecoveryModule.lightning,
+    PaymentType.onchain => RecoveryModule.onchain,
+    PaymentType.ecash => RecoveryModule.ecash,
+  };
+}

--- a/lib/multimint.dart
+++ b/lib/multimint.dart
@@ -11,9 +11,9 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'package:freezed_annotation/freezed_annotation.dart' hide protected;
 part 'multimint.freezed.dart';
 
-// These functions are ignored because they are not marked as `pub`: `await_receive_lnv1`, `await_receive_lnv2`, `await_send_lnv1`, `await_send_lnv2`, `backup`, `build_client`, `cache_btc_price`, `cache_federation_meta`, `check_for_update`, `compute_send_fees`, `extract_recipient_pk_from_lnv2_lnurl`, `finish_active_subscriptions`, `from_peg_out_fees`, `get_client_database`, `get_client`, `get_ecash_amount_from_meta`, `get_lnv1_amount_from_meta`, `get_lnv1_receive_tx`, `get_lnv1_send_tx`, `get_lnv2_amount_from_meta`, `get_mintv2_receive_amount`, `get_or_build_temp_client`, `get_recurringd_federations`, `get_url`, `gross_invoice_for_contract`, `guardian_admin_api`, `guardian_bitcoin_status`, `guardian_lnv2_module_api`, `guardian_meta_consensus`, `guardian_meta_module_api`, `guardian_meta_submit`, `init_recovery_progress_cache`, `invoice_is_loopback`, `is_invalid_guardian_auth`, `is_newer_version`, `list_gateways`, `lnv1_update_gateway_cache`, `lnv2_gateways`, `load_clients`, `pay_lnv1`, `pay_lnv2`, `read_meta_msats`, `read_meta_string`, `read_meta_u64`, `read_meta_url`, `receive_lnv1`, `receive_lnv2`, `release_ln_address`, `remove_recovery_progress_cache`, `run_cache_stage`, `run_migrations`, `send_federation_fee`, `sign_challenge`, `skip_unrenderable`, `solve_gross_for_net`, `spawn_await_ecash_reissue`, `spawn_await_ecash_send`, `spawn_await_mintv2_receive`, `spawn_await_receive`, `spawn_await_recurringd_receive`, `spawn_await_send`, `spawn_await_withdraw`, `spawn_backfill_recipient_pk`, `spawn_cache_task`, `spawn_lnv2_event_listener`, `spawn_recovery_progress`, `spawn_recurring_invoice_listener`, `update_recovery_progress_cache`, `validate_receive_fee`, `wait_for_recovery`, `wallet_network`
+// These functions are ignored because they are not marked as `pub`: `aggregate_recovery_progress`, `await_receive_lnv1`, `await_receive_lnv2`, `await_send_lnv1`, `await_send_lnv2`, `backup`, `build_client`, `cache_btc_price`, `cache_federation_meta`, `check_for_update`, `compute_send_fees`, `extract_recipient_pk_from_lnv2_lnurl`, `finish_active_subscriptions`, `from_peg_out_fees`, `get_client_database`, `get_client`, `get_ecash_amount_from_meta`, `get_lnv1_amount_from_meta`, `get_lnv1_receive_tx`, `get_lnv1_send_tx`, `get_lnv2_amount_from_meta`, `get_mintv2_receive_amount`, `get_or_build_temp_client`, `get_recurringd_federations`, `get_url`, `gross_invoice_for_contract`, `guardian_admin_api`, `guardian_bitcoin_status`, `guardian_lnv2_module_api`, `guardian_meta_consensus`, `guardian_meta_module_api`, `guardian_meta_submit`, `init_recovery_progress_cache`, `invoice_is_loopback`, `is_invalid_guardian_auth`, `is_newer_version`, `list_gateways`, `lnv1_update_gateway_cache`, `lnv2_gateways`, `load_clients`, `pay_lnv1`, `pay_lnv2`, `read_meta_msats`, `read_meta_string`, `read_meta_u64`, `read_meta_url`, `receive_lnv1`, `receive_lnv2`, `recovery_module_for_kind`, `release_ln_address`, `remove_recovery_progress_cache`, `run_cache_stage`, `run_migrations`, `send_federation_fee`, `sign_challenge`, `skip_unrenderable`, `solve_gross_for_net`, `spawn_await_ecash_reissue`, `spawn_await_ecash_send`, `spawn_await_mintv2_receive`, `spawn_await_receive`, `spawn_await_recurringd_receive`, `spawn_await_send`, `spawn_await_withdraw`, `spawn_backfill_recipient_pk`, `spawn_cache_task`, `spawn_lnv2_event_listener`, `spawn_recovery_progress`, `spawn_recurring_invoice_listener`, `update_recovery_progress_cache`, `validate_receive_fee`, `wait_for_recovery`, `wallet_network`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `ClientType`, `LNAddressRegisterRequest`, `LNAddressRemoveRequest`, `OnChainWithdrawalMeta`, `WrappedEcash`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `consensus_decode_partial_from_finite_reader`, `consensus_decode_partial_from_finite_reader`, `consensus_decode_partial_from_finite_reader`, `consensus_encode`, `consensus_encode`, `consensus_encode`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `cmp`, `consensus_decode_partial_from_finite_reader`, `consensus_decode_partial_from_finite_reader`, `consensus_decode_partial_from_finite_reader`, `consensus_encode`, `consensus_encode`, `consensus_encode`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `partial_cmp`
 // These functions are ignored (category: IgnoreBecauseExplicitAttribute): `federation_network`
 // These functions have error during generation (see debug logs or enable `stop_on_error: true` for more details): `subscribe_peer_status`
 
@@ -259,7 +259,7 @@ abstract class Multimint implements RustOpaqueInterface {
 
   Future<RecoveryProgress> getRecoveryProgress({
     required FederationId federationId,
-    required int moduleId,
+    required RecoveryModule recoveryModule,
   });
 
   Future<bool> getShowMsats();
@@ -1226,7 +1226,7 @@ sealed class MultimintEvent with _$MultimintEvent {
       MultimintEvent_RecoveryDone;
   const factory MultimintEvent.recoveryProgress(
     String field0,
-    int field1,
+    RecoveryModule field1,
     int field2,
     int field3,
   ) = MultimintEvent_RecoveryProgress;
@@ -1441,6 +1441,19 @@ class ReceiveAmount {
           federationFeeMsats == other.federationFeeMsats &&
           gatewayFeeMsats == other.gatewayFeeMsats;
 }
+
+/// The wallet-facing grouping a recovering Fedimint module belongs to.
+///
+/// The dashboard shows one recovery bar per payment type, but a federation can
+/// run more than one module behind a single bar (`mint` and `mintv2` both back
+/// Ecash), and the module instance ids themselves are not stable: guardians
+/// assign them by enumerating the *enabled* modules in alphabetical order of
+/// kind, so a v2-only federation numbers them lnv2=0, meta=1, mintv2=2,
+/// walletv2=3 while a legacy one numbers them ln=0, mint=1, wallet=2. Resolving
+/// the kind here and keying progress on this enum keeps the instance ids on the
+/// Rust side, where the client config can be consulted, instead of hardcoding a
+/// layout in the UI.
+enum RecoveryModule { lightning, ecash, onchain }
 
 class ReissueFees {
   final BigInt totalMsats;

--- a/lib/multimint.freezed.dart
+++ b/lib/multimint.freezed.dart
@@ -1563,7 +1563,7 @@ class MultimintEvent_RecoveryProgress extends MultimintEvent {
   
 
 @override final  String field0;
- final  int field1;
+ final  RecoveryModule field1;
  final  int field2;
  final  int field3;
 
@@ -1597,7 +1597,7 @@ abstract mixin class $MultimintEvent_RecoveryProgressCopyWith<$Res> implements $
   factory $MultimintEvent_RecoveryProgressCopyWith(MultimintEvent_RecoveryProgress value, $Res Function(MultimintEvent_RecoveryProgress) _then) = _$MultimintEvent_RecoveryProgressCopyWithImpl;
 @useResult
 $Res call({
- String field0, int field1, int field2, int field3
+ String field0, RecoveryModule field1, int field2, int field3
 });
 
 
@@ -1618,7 +1618,7 @@ class _$MultimintEvent_RecoveryProgressCopyWithImpl<$Res>
   return _then(MultimintEvent_RecoveryProgress(
 null == field0 ? _self.field0 : field0 // ignore: cast_nullable_to_non_nullable
 as String,null == field1 ? _self.field1 : field1 // ignore: cast_nullable_to_non_nullable
-as int,null == field2 ? _self.field2 : field2 // ignore: cast_nullable_to_non_nullable
+as RecoveryModule,null == field2 ? _self.field2 : field2 // ignore: cast_nullable_to_non_nullable
 as int,null == field3 ? _self.field3 : field3 // ignore: cast_nullable_to_non_nullable
 as int,
   ));

--- a/lib/recovery_progress.dart
+++ b/lib/recovery_progress.dart
@@ -39,7 +39,7 @@ class _RecoveryStatusState extends State<RecoveryStatus> {
     final progressEvents =
         subscribeRecoveryProgress(
           federationId: widget.fed.federationId,
-          moduleId: getModuleIdForPaymentType(widget.paymentType),
+          recoveryModule: widget.paymentType.recoveryModule,
         ).asBroadcastStream();
     _progressSubscription = progressEvents.listen((e) {
       if (e.$2 > 0) {

--- a/lib/screens/dashboard.dart
+++ b/lib/screens/dashboard.dart
@@ -45,7 +45,11 @@ class _DashboardState extends State<Dashboard> {
   BigInt? balanceMsats;
   bool isLoadingBalance = true;
   late bool recovering;
-  double _recoveryProgress = 0.0;
+
+  /// Recovery progress per payment type. Keeping one entry per tab stops a
+  /// tab whose modules report nothing from showing the previously selected
+  /// tab's bar.
+  final Map<PaymentType, double> _recoveryProgress = {};
   PaymentType _selectedPaymentType = PaymentType.lightning;
   Map<FiatCurrency, double> _btcPrices = {};
   bool _isLoadingPrices = false;
@@ -374,16 +378,18 @@ class _DashboardState extends State<Dashboard> {
     if (recovering) {
       final progress = await getModuleRecoveryProgress(
         federationId: widget.fed.federationId,
-        moduleId: getModuleIdForPaymentType(paymentType),
+        recoveryModule: paymentType.recoveryModule,
       );
 
       if (progress.$2 > 0) {
         double rawProgress = progress.$1.toDouble() / progress.$2.toDouble();
-        setState(() => _recoveryProgress = rawProgress.clamp(0.0, 1.0));
+        setState(
+          () => _recoveryProgress[paymentType] = rawProgress.clamp(0.0, 1.0),
+        );
       }
 
       AppLogger.instance.info(
-        "$_selectedPaymentType progress: $_recoveryProgress complete: ${progress.$1} total: ${progress.$2}",
+        "$paymentType progress: ${_recoveryProgress[paymentType] ?? 0.0} complete: ${progress.$1} total: ${progress.$2}",
       );
     }
   }
@@ -462,7 +468,8 @@ class _DashboardState extends State<Dashboard> {
                       key: ValueKey(_selectedPaymentType),
                       paymentType: _selectedPaymentType,
                       fed: widget.fed,
-                      initialProgress: _recoveryProgress,
+                      initialProgress:
+                          _recoveryProgress[_selectedPaymentType] ?? 0.0,
                     ),
                     const Spacer(),
                   ],

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 import 'package:ecashapp/db.dart';
 import 'package:ecashapp/extensions/build_context_l10n.dart';
 import 'package:ecashapp/lib.dart';
-import 'package:ecashapp/models.dart';
 import 'package:ecashapp/multimint.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -289,17 +288,6 @@ String formatFiatInput(String rawFiatInput, FiatCurrency fiatCurrency) {
   return symbolPosition == 'before'
       ? '$symbol$formattedValue'
       : '$formattedValue$symbol';
-}
-
-int getModuleIdForPaymentType(PaymentType paymentType) {
-  switch (paymentType) {
-    case PaymentType.lightning:
-      return 0;
-    case PaymentType.ecash:
-      return 1;
-    case PaymentType.onchain:
-      return 2;
-  }
 }
 
 Future<Map<FiatCurrency, double>> fetchAllBtcPrices() async {

--- a/rust/ecashapp/src/frb_generated.rs
+++ b/rust/ecashapp/src/frb_generated.rs
@@ -4322,7 +4322,8 @@ fn wire__crate__multimint__Multimint_get_recovery_progress_impl(
             let api_federation_id = <RustOpaqueMoi<
                 flutter_rust_bridge::for_generated::RustAutoOpaqueInner<FederationId>,
             >>::sse_decode(&mut deserializer);
-            let api_module_id = <u16>::sse_decode(&mut deserializer);
+            let api_recovery_module =
+                <crate::multimint::RecoveryModule>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| async move {
                 transform_result_sse::<_, ()>(
@@ -4361,7 +4362,7 @@ fn wire__crate__multimint__Multimint_get_recovery_progress_impl(
                             crate::multimint::Multimint::get_recovery_progress(
                                 &*api_that_guard,
                                 &*api_federation_id_guard,
-                                api_module_id,
+                                api_recovery_module,
                             )
                             .await,
                         )?;
@@ -11758,7 +11759,8 @@ fn wire__crate__get_module_recovery_progress_impl(
             let api_federation_id = <RustOpaqueMoi<
                 flutter_rust_bridge::for_generated::RustAutoOpaqueInner<FederationId>,
             >>::sse_decode(&mut deserializer);
-            let api_module_id = <u16>::sse_decode(&mut deserializer);
+            let api_recovery_module =
+                <crate::multimint::RecoveryModule>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| async move {
                 transform_result_sse::<_, ()>(
@@ -11785,7 +11787,7 @@ fn wire__crate__get_module_recovery_progress_impl(
                         let output_ok = Result::<_, ()>::Ok(
                             crate::get_module_recovery_progress(
                                 &*api_federation_id_guard,
-                                api_module_id,
+                                api_recovery_module,
                             )
                             .await,
                         )?;
@@ -14758,7 +14760,8 @@ fn wire__crate__subscribe_recovery_progress_impl(
                     &mut deserializer,
                 );
             let api_federation_id = <FederationId>::sse_decode(&mut deserializer);
-            let api_module_id = <u16>::sse_decode(&mut deserializer);
+            let api_recovery_module =
+                <crate::multimint::RecoveryModule>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| async move {
                 transform_result_sse::<_, ()>(
@@ -14767,7 +14770,7 @@ fn wire__crate__subscribe_recovery_progress_impl(
                             crate::subscribe_recovery_progress(
                                 api_sink,
                                 api_federation_id,
-                                api_module_id,
+                                api_recovery_module,
                             )
                             .await;
                         })?;
@@ -16840,7 +16843,7 @@ impl SseDecode for crate::multimint::MultimintEvent {
             }
             4 => {
                 let mut var_field0 = <String>::sse_decode(deserializer);
-                let mut var_field1 = <u16>::sse_decode(deserializer);
+                let mut var_field1 = <crate::multimint::RecoveryModule>::sse_decode(deserializer);
                 let mut var_field2 = <u32>::sse_decode(deserializer);
                 let mut var_field3 = <u32>::sse_decode(deserializer);
                 return crate::multimint::MultimintEvent::RecoveryProgress(
@@ -17437,6 +17440,19 @@ impl SseDecode for (u64, usize) {
         let mut var_field0 = <u64>::sse_decode(deserializer);
         let mut var_field1 = <usize>::sse_decode(deserializer);
         return (var_field0, var_field1);
+    }
+}
+
+impl SseDecode for crate::multimint::RecoveryModule {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <i32>::sse_decode(deserializer);
+        return match inner {
+            0 => crate::multimint::RecoveryModule::Lightning,
+            1 => crate::multimint::RecoveryModule::Ecash,
+            2 => crate::multimint::RecoveryModule::Onchain,
+            _ => unreachable!("Invalid variant for RecoveryModule: {}", inner),
+        };
     }
 }
 
@@ -20167,6 +20183,28 @@ impl flutter_rust_bridge::IntoIntoDart<crate::multimint::ReceiveAmount>
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::multimint::RecoveryModule {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        match self {
+            Self::Lightning => 0.into_dart(),
+            Self::Ecash => 1.into_dart(),
+            Self::Onchain => 2.into_dart(),
+            _ => unreachable!(),
+        }
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::multimint::RecoveryModule
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::multimint::RecoveryModule>
+    for crate::multimint::RecoveryModule
+{
+    fn into_into_dart(self) -> crate::multimint::RecoveryModule {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::multimint::ReissueFees {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
@@ -21812,7 +21850,7 @@ impl SseEncode for crate::multimint::MultimintEvent {
             crate::multimint::MultimintEvent::RecoveryProgress(field0, field1, field2, field3) => {
                 <i32>::sse_encode(4, serializer);
                 <String>::sse_encode(field0, serializer);
-                <u16>::sse_encode(field1, serializer);
+                <crate::multimint::RecoveryModule>::sse_encode(field1, serializer);
                 <u32>::sse_encode(field2, serializer);
                 <u32>::sse_encode(field3, serializer);
             }
@@ -22326,6 +22364,23 @@ impl SseEncode for (u64, usize) {
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <u64>::sse_encode(self.0, serializer);
         <usize>::sse_encode(self.1, serializer);
+    }
+}
+
+impl SseEncode for crate::multimint::RecoveryModule {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(
+            match self {
+                crate::multimint::RecoveryModule::Lightning => 0,
+                crate::multimint::RecoveryModule::Ecash => 1,
+                crate::multimint::RecoveryModule::Onchain => 2,
+                _ => {
+                    unimplemented!("");
+                }
+            },
+            serializer,
+        );
     }
 }
 

--- a/rust/ecashapp/src/lib.rs
+++ b/rust/ecashapp/src/lib.rs
@@ -29,8 +29,8 @@ use multimint::{
     EcashSendFees, FederationMeta, FederationSelector, GuardianAuditSummary,
     GuardianBackupStatistics, GuardianMetaState, GuardianStatusSummary, LightningSendOutcome,
     LogLevel, Multimint, MultimintCreation, MultimintEvent, OOBNotesWrapper,
-    PaymentPreviewWithGateways, PeginFeeQuote, ReceiveAmount, ReissueFees, Transaction, Utxo,
-    WithdrawFees, WithdrawFeesResponse,
+    PaymentPreviewWithGateways, PeginFeeQuote, ReceiveAmount, RecoveryModule, ReissueFees,
+    Transaction, Utxo, WithdrawFees, WithdrawFeesResponse,
 };
 use nostr::{NWCConnectionInfo, NostrClient, PublicFederation};
 use serde::Serialize;
@@ -991,11 +991,11 @@ pub async fn get_max_withdrawable_amount(
 #[frb]
 pub async fn get_module_recovery_progress(
     federation_id: &FederationId,
-    module_id: u16,
+    recovery_module: RecoveryModule,
 ) -> (u32, u32) {
     let multimint = get_multimint();
     let progress = multimint
-        .get_recovery_progress(federation_id, module_id)
+        .get_recovery_progress(federation_id, recovery_module)
         .await;
     (progress.complete, progress.total)
 }
@@ -1004,16 +1004,16 @@ pub async fn get_module_recovery_progress(
 pub async fn subscribe_recovery_progress(
     sink: StreamSink<(u32, u32)>,
     federation_id: FederationId,
-    module_id: u16,
+    recovery_module: RecoveryModule,
 ) {
     let event_bus = get_event_bus();
     let mut stream = event_bus.subscribe();
 
     while let Some(evt) = stream.next().await {
-        if let MultimintEvent::RecoveryProgress(evt_fed_id, evt_module_id, complete, total) = evt {
+        if let MultimintEvent::RecoveryProgress(evt_fed_id, evt_module, complete, total) = evt {
             let event_federation_id =
                 FederationId::from_str(&evt_fed_id).expect("Could not parse FederationId");
-            if event_federation_id == federation_id && evt_module_id == module_id {
+            if event_federation_id == federation_id && evt_module == recovery_module {
                 if sink.add((complete, total)).is_err() {
                     break;
                 }

--- a/rust/ecashapp/src/multimint.rs
+++ b/rust/ecashapp/src/multimint.rs
@@ -30,6 +30,7 @@ use fedimint_core::{
     admin_client::ServerStatusLegacy,
     base32::{decode_prefixed, encode_prefixed, FEDIMINT_PREFIX},
     config::{FederationId, META_FEDERATION_NAME_KEY},
+    core::{ModuleInstanceId, ModuleKind},
     db::{mem_impl::MemDatabase, Database, IDatabaseTransactionOpsCoreTyped},
     encoding::{Decodable, Encodable},
     endpoint_constants::CONSENSUS_ORD_LATENCY_ENDPOINT,
@@ -299,7 +300,14 @@ pub struct Multimint {
     modules: ClientModuleInitRegistry,
     clients: Arc<RwLock<BTreeMap<FederationId, ClientHandleArc>>>,
     task_group: TaskGroup,
-    recovery_progress: Arc<RwLock<BTreeMap<FederationId, BTreeMap<u16, RecoveryProgress>>>>,
+    /// Per-federation recovery progress, keyed by module instance id so each
+    /// module's updates overwrite only its own entry, and tagged with the bar
+    /// it feeds so reads can aggregate across the modules sharing one.
+    recovery_progress: Arc<
+        RwLock<
+            BTreeMap<FederationId, BTreeMap<ModuleInstanceId, (RecoveryModule, RecoveryProgress)>>,
+        >,
+    >,
     internal_ecash_spends: Arc<RwLock<BTreeSet<OperationId>>>,
     recurringd_invoices: Arc<RwLock<BTreeSet<OperationId>>>,
     update_notified: Arc<AtomicBool>,
@@ -687,13 +695,67 @@ pub enum NostrRecoveryPhase {
     NoBackupFound,
 }
 
+/// The wallet-facing grouping a recovering Fedimint module belongs to.
+///
+/// The dashboard shows one recovery bar per payment type, but a federation can
+/// run more than one module behind a single bar (`mint` and `mintv2` both back
+/// Ecash), and the module instance ids themselves are not stable: guardians
+/// assign them by enumerating the *enabled* modules in alphabetical order of
+/// kind, so a v2-only federation numbers them lnv2=0, meta=1, mintv2=2,
+/// walletv2=3 while a legacy one numbers them ln=0, mint=1, wallet=2. Resolving
+/// the kind here and keying progress on this enum keeps the instance ids on the
+/// Rust side, where the client config can be consulted, instead of hardcoding a
+/// layout in the UI.
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Serialize, Debug)]
+pub enum RecoveryModule {
+    Lightning,
+    Ecash,
+    Onchain,
+}
+
+/// Maps a module kind to the recovery bar it feeds, or `None` for kinds with no
+/// bar of their own (`meta`, and anything a future federation adds).
+fn recovery_module_for_kind(kind: &ModuleKind) -> Option<RecoveryModule> {
+    if *kind == fedimint_ln_common::KIND || *kind == fedimint_lnv2_common::KIND {
+        Some(RecoveryModule::Lightning)
+    } else if *kind == fedimint_mint_common::KIND || *kind == fedimint_mintv2_common::KIND {
+        Some(RecoveryModule::Ecash)
+    } else if *kind == fedimint_wallet_common::KIND || *kind == fedimint_walletv2_common::KIND {
+        Some(RecoveryModule::Onchain)
+    } else {
+        None
+    }
+}
+
+/// Sums the progress of every module feeding one recovery bar.
+///
+/// A federation can run both the v1 and v2 module of a kind, and each recovers
+/// independently. Reporting only one of them would stall the bar partway;
+/// summing gives a single monotonic ratio. Modules that don't implement
+/// recovery report 0/0 and so contribute nothing, which is what leaves the
+/// Lightning bar empty — neither `ln` nor `lnv2` has a recovery routine.
+fn aggregate_recovery_progress(
+    module_progress: &BTreeMap<ModuleInstanceId, (RecoveryModule, RecoveryProgress)>,
+    recovery_module: RecoveryModule,
+) -> RecoveryProgress {
+    module_progress
+        .values()
+        .filter(|(module, _)| *module == recovery_module)
+        .fold(RecoveryProgress::none(), |acc, (_, progress)| {
+            RecoveryProgress {
+                complete: acc.complete.saturating_add(progress.complete),
+                total: acc.total.saturating_add(progress.total),
+            }
+        })
+}
+
 #[derive(Clone, Eq, PartialEq, Serialize, Debug)]
 pub enum MultimintEvent {
     Deposit((FederationId, DepositEventKind)),
     Lightning((FederationId, LightningEventKind)),
     Log(LogLevel, String),
     RecoveryDone(String),
-    RecoveryProgress(String, u16, u32, u32),
+    RecoveryProgress(String, RecoveryModule, u32, u32),
     Ecash((FederationId, u64)),
     NostrRecovery(String, u16, Option<FederationSelector>),
     NostrRelayStatus(String, RelayStatusKind),
@@ -2058,12 +2120,31 @@ impl Multimint {
                     .init_recovery_progress_cache(client.federation_id())
                     .await;
 
+                // Instance ids are assigned per federation, so the mapping has
+                // to come from this client's config rather than a fixed layout.
+                let recovery_modules: BTreeMap<ModuleInstanceId, RecoveryModule> = client
+                    .config()
+                    .await
+                    .modules
+                    .iter()
+                    .filter_map(|(id, module)| {
+                        recovery_module_for_kind(&module.kind).map(|m| (*id, m))
+                    })
+                    .collect();
+
                 let mut stream = client.subscribe_to_recovery_progress();
                 while let Some((module_id, progress)) = stream.next().await {
+                    // Kinds with no bar of their own (`meta`) still recover and
+                    // still report; they just have nowhere to be shown.
+                    let Some(recovery_module) = recovery_modules.get(&module_id).copied() else {
+                        continue;
+                    };
+
                     progress_copy
                         .update_recovery_progress_cache(
                             &client.federation_id(),
                             module_id,
+                            recovery_module,
                             progress,
                         )
                         .await;
@@ -2088,19 +2169,29 @@ impl Multimint {
     async fn update_recovery_progress_cache(
         &self,
         federation_id: &FederationId,
-        module_id: u16,
+        module_id: ModuleInstanceId,
+        recovery_module: RecoveryModule,
         module_progress: RecoveryProgress,
     ) {
-        let mut progress = self.recovery_progress.write().await;
-        if let Some(module_progress_cache) = progress.get_mut(federation_id) {
-            module_progress_cache.insert(module_id, module_progress);
-        }
+        let aggregated = {
+            let mut progress = self.recovery_progress.write().await;
+            let Some(module_progress_cache) = progress.get_mut(federation_id) else {
+                // The federation was removed while its recovery was running.
+                return;
+            };
+            module_progress_cache.insert(module_id, (recovery_module, module_progress));
+            aggregate_recovery_progress(module_progress_cache, recovery_module)
+        };
+
+        // Publish the aggregate rather than this one module's slice, so the
+        // stream and `get_recovery_progress` never disagree on a federation
+        // running both `mint` and `mintv2` behind the same bar.
         get_event_bus()
             .publish(MultimintEvent::RecoveryProgress(
                 federation_id.to_string(),
-                module_id,
-                module_progress.complete,
-                module_progress.total,
+                recovery_module,
+                aggregated.complete,
+                aggregated.total,
             ))
             .await;
     }
@@ -2108,20 +2199,13 @@ impl Multimint {
     pub async fn get_recovery_progress(
         &self,
         federation_id: &FederationId,
-        module_id: u16,
+        recovery_module: RecoveryModule,
     ) -> RecoveryProgress {
         let progress = self.recovery_progress.read().await;
-        let module_progress = progress.get(federation_id);
-        if let Some(module_progress) = module_progress {
-            if let Some(progress) = module_progress.get(&module_id) {
-                return *progress;
-            }
-        }
-
-        RecoveryProgress {
-            complete: 0,
-            total: 0,
-        }
+        progress
+            .get(federation_id)
+            .map(|module_progress| aggregate_recovery_progress(module_progress, recovery_module))
+            .unwrap_or_else(RecoveryProgress::none)
     }
 
     async fn wait_for_recovery(
@@ -6508,9 +6592,16 @@ fn validate_receive_fee(receive_fee: &PaymentFee) -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
+    use fedimint_client::module::module::recovery::RecoveryProgress;
+    use fedimint_core::core::ModuleKind;
     use fedimint_lnv2_common::gateway_api::PaymentFee;
 
-    use crate::multimint::{gross_invoice_for_contract, MAX_GATEWAY_PPM};
+    use crate::multimint::{
+        aggregate_recovery_progress, gross_invoice_for_contract, recovery_module_for_kind,
+        RecoveryModule, MAX_GATEWAY_PPM,
+    };
 
     fn payment_fee(base_msats: u64, ppm: u64) -> PaymentFee {
         PaymentFee {
@@ -6577,5 +6668,103 @@ mod tests {
             err.to_string().contains("overflows") || err.to_string().contains("too large"),
             "got: {err}"
         );
+    }
+
+    /// The bug this replaced: the UI hardcoded lightning=0, ecash=1, onchain=2,
+    /// which is only the *legacy* layout. Guardians number modules by
+    /// enumerating the enabled ones alphabetically by kind, so this table is
+    /// what has to be consulted instead of a fixed id.
+    #[test]
+    fn maps_both_module_generations_to_one_bar() {
+        let cases = [
+            ("ln", Some(RecoveryModule::Lightning)),
+            ("lnv2", Some(RecoveryModule::Lightning)),
+            ("mint", Some(RecoveryModule::Ecash)),
+            ("mintv2", Some(RecoveryModule::Ecash)),
+            ("wallet", Some(RecoveryModule::Onchain)),
+            ("walletv2", Some(RecoveryModule::Onchain)),
+            // `meta` recovers alongside the rest but has no bar; on a v2-only
+            // federation it lands on instance id 1, exactly where the old code
+            // looked for ecash.
+            ("meta", None),
+            ("unknown", None),
+        ];
+
+        for (kind, expected) in cases {
+            assert_eq!(
+                recovery_module_for_kind(&ModuleKind::clone_from_str(kind)),
+                expected,
+                "kind {kind}"
+            );
+        }
+    }
+
+    fn progress(complete: u32, total: u32) -> RecoveryProgress {
+        RecoveryProgress { complete, total }
+    }
+
+    /// `RecoveryProgress` is a foreign type with no `PartialEq`.
+    fn assert_progress(actual: RecoveryProgress, complete: u32, total: u32) {
+        assert_eq!(
+            (actual.complete, actual.total),
+            (complete, total),
+            "recovery progress"
+        );
+    }
+
+    /// Instance ids here are the alphabetical layout a v2-only federation gets:
+    /// lnv2=0, meta=1, mintv2=2, walletv2=3.
+    #[test]
+    fn aggregates_only_the_modules_behind_the_requested_bar() {
+        let cache = BTreeMap::from([
+            (0, (RecoveryModule::Lightning, progress(0, 0))),
+            (2, (RecoveryModule::Ecash, progress(30, 100))),
+            (3, (RecoveryModule::Onchain, progress(0, 0))),
+        ]);
+
+        assert_progress(
+            aggregate_recovery_progress(&cache, RecoveryModule::Ecash),
+            30,
+            100,
+        );
+        // Reading id 2 as "onchain", as the old hardcoded map did, is what
+        // showed ecash progress under the On-chain tab.
+        assert_progress(
+            aggregate_recovery_progress(&cache, RecoveryModule::Onchain),
+            0,
+            0,
+        );
+        assert_progress(
+            aggregate_recovery_progress(&cache, RecoveryModule::Lightning),
+            0,
+            0,
+        );
+    }
+
+    #[test]
+    fn sums_a_federation_running_both_mint_generations() {
+        let cache = BTreeMap::from([
+            (0, (RecoveryModule::Ecash, progress(40, 100))),
+            (1, (RecoveryModule::Ecash, progress(10, 50))),
+        ]);
+
+        // One bar, both modules: 50/150 rather than whichever reported last.
+        assert_progress(
+            aggregate_recovery_progress(&cache, RecoveryModule::Ecash),
+            50,
+            150,
+        );
+    }
+
+    #[test]
+    fn a_bar_with_no_modules_reports_nothing_rather_than_complete() {
+        // total == 0 is what the UI keys on to leave the bar alone, so an empty
+        // cache must not come back looking like a finished recovery.
+        let empty = BTreeMap::new();
+        let result = aggregate_recovery_progress(&empty, RecoveryModule::Ecash);
+
+        assert_progress(result, 0, 0);
+        assert!(result.is_none());
+        assert!(!result.is_done());
     }
 }

--- a/rust/ecashapp/src/wallet/mod.rs
+++ b/rust/ecashapp/src/wallet/mod.rs
@@ -1126,7 +1126,7 @@ fn mempool_api_url(network: bitcoin::Network) -> String {
         bitcoin::Network::Bitcoin => "https://mempool.space/api".to_string(),
         bitcoin::Network::Signet => "https://mutinynet.com/api".to_string(),
         bitcoin::Network::Regtest => {
-            "http://127.0.0.1:10567".to_string()
+            "http://127.0.0.1:15641".to_string()
             //panic!("Regtest requires manually setting the connection params")
         }
         network => {


### PR DESCRIPTION
Ecash App codebase still relied on hardcoded module ids, which are way out of date. We had a dart function called `getModuleIdForPaymentType` which mapped the payment type to the module id. This would cause a UI bug during recovery which resulted in the incorrect progress being shown to the user. Not a functional issue, funds were never at risk.

This PR fixes it by removing `getModuleIdForPaymentType` and implementing the recovery progress correctly.