### PR TITLE
fix: exclude wallet data from Android backup and device transfer

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -16,7 +16,9 @@
         android:label="Ecash App"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
-        android:localeConfig="@xml/locales_config">
+        android:localeConfig="@xml/locales_config"
+        android:allowBackup="false"
+        android:dataExtractionRules="@xml/data_extraction_rules">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="root" path="." />
+        <exclude domain="file" path="." />
+        <exclude domain="database" path="." />
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="external" path="." />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="root" path="." />
+        <exclude domain="file" path="." />
+        <exclude domain="database" path="." />
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="external" path="." />
+    </device-transfer>
+</data-extraction-rules>


### PR DESCRIPTION
`AndroidManifest.xml` declared no `android:allowBackup`, so it defaulted to true.
Two backup domains are involved, not one:

| Artifact | Path | Domain |
|---|---|---|
| `client.db` (seed, NWC keys, PIN) | `<dataDir>/app_flutter/` | `root` |
| `ecashapp.txt` (plaintext log) | `getExternalFilesDir()/ecashapp/` | `external` |

On Android `getApplicationDocumentsDirectory()` is not a Documents folder — it maps to `context.getDir("flutter")`, i.e. `app_flutter`. The log takes a different route entirely (`lib/utils.dart:41` uses `getExternalStorageDirectory()`), and Auto Backup covers that by default too, so excluding only the DB's location would have left the log — which per the audit can contain a pasted seed phrase — syncing to Drive.

`allowBackup="false"` alone is not sufficient: on API 31+ it stops Drive backup but not device-to-device transfer. `dataExtractionRules` therefore excludes every domain from both `<cloud-backup>` and `<device-transfer>`. Excluding whole domains rather than named paths keeps anything added later covered, since `app_flutter` is a Flutter implementation detail.

Nothing here is worth preserving — recovery is seed phrase plus Nostr invite codes, and preferences live in the same RocksDB as the seed.