### PR TITLE
fix: warn that copied ecash is spendable

### DIFF
--- a/lib/ecash_send.dart
+++ b/lib/ecash_send.dart
@@ -357,12 +357,18 @@ class _EcashSendState extends State<EcashSend> {
               child: Row(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  const Icon(Icons.warning, color: Colors.orange, size: 20),
+                  // Foreground is brown.shade900 rather than an orange: on this
+                  // orange.shade100 background `Colors.orange` gives a contrast
+                  // ratio of 1.7:1, far below the 4.5:1 WCAG AA needs for body
+                  // text, and a warning nobody can comfortably read defeats the
+                  // point. Darker oranges are not enough either — shade900 only
+                  // reaches 3.0:1 — whereas this keeps the warm tone at 10.9:1.
+                  Icon(Icons.warning, color: Colors.brown.shade900, size: 20),
                   const SizedBox(width: 8),
                   Expanded(
                     child: Text(
                       context.l10n.ecashClipboardWarning,
-                      style: const TextStyle(color: Colors.orange),
+                      style: TextStyle(color: Colors.brown.shade900),
                     ),
                   ),
                 ],

--- a/lib/ecash_send.dart
+++ b/lib/ecash_send.dart
@@ -288,7 +288,7 @@ class _EcashSendState extends State<EcashSend> {
     // redeems it first owns it, so it must not reach a screenshot, a screen
     // recording, or the app-switcher thumbnail.
     return SecureScreen(
-      child: Padding(
+      child: SingleChildScrollView(
         padding: const EdgeInsets.all(20),
         child: Column(
           mainAxisSize: MainAxisSize.min,
@@ -344,6 +344,31 @@ class _EcashSendState extends State<EcashSend> {
               },
             ),
             const SizedBox(height: 24),
+            // The token below is a bearer instrument, and the copy button hands
+            // it to a clipboard that other apps, input methods and sync services
+            // can read. State that plainly next to the control rather than after
+            // the fact, so the user knows before they tap.
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: Colors.orange.shade100,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Icon(Icons.warning, color: Colors.orange, size: 20),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      context.l10n.ecashClipboardWarning,
+                      style: const TextStyle(color: Colors.orange),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 12),
             Container(
               padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
               decoration: BoxDecoration(

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1321,6 +1321,9 @@
   "ecashCopiedToClipboard": "Ecash copied to clipboard",
   "@ecashCopiedToClipboard": {},
 
+  "ecashClipboardWarning": "Anyone who reads this token can spend it. Other apps can read your clipboard, so only paste it where you intend to send the funds.",
+  "@ecashClipboardWarning": {},
+
   "federationLabel": "Federation",
   "@federationLabel": {},
 

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -373,6 +373,7 @@
   "failedToLoadEcash": "Error al cargar Ecash",
   "ecashWithdrawn": "Ecash retirado",
   "ecashCopiedToClipboard": "Ecash copiado al portapapeles",
+  "ecashClipboardWarning": "Cualquiera que lea este token puede gastarlo. Otras aplicaciones pueden leer tu portapapeles, así que pégalo solo donde quieras enviar los fondos.",
   "federationLabel": "Federación",
   "confirmPayment": "Confirmar pago",
   "amountSpent": "{amount} gastado",


### PR DESCRIPTION
The copy button on the ecash send screen hands a bearer instrument to the clipboard, which other apps, input methods and clipboard-sync services can read. Nothing on screen said so (fixes #534, security audit L23).

Adds a persistent warning directly above the token and its copy button, so it is read before the tap rather than shown as a toast afterwards. A persistent note is used instead of a one-time dialog because the risk applies to every copy, and because it needs no persisted "already warned" state.

The screen is presented in a fixed-height bottom sheet and was a plain non-scrolling Column already holding a square QR, so the outer padding becomes a SingleChildScrollView to keep the added banner from overflowing on shorter screens.