### PR TITLE
chore: bump fedimint dependencies to v0.12

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,7 +128,7 @@ When modifying the Rust API:
 
 ### Fedimint Integration
 
-The app uses Fedimint SDK v0.9.0 with these modules:
+The app uses Fedimint SDK v0.12.0 with these modules:
 - **fedimint-mint-client** - Ecash mint operations
 - **fedimint-ln-client** - Lightning v1 (legacy)
 - **fedimint-lnv2-client** - Lightning v2 (preferred for new gateways)

--- a/flake.lock
+++ b/flake.lock
@@ -57,17 +57,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1762287806,
-        "narHash": "sha256-tmF7Fm2VNukLV32w60QiFLDJB4cO26lhKdDLR8k1BX0=",
+        "lastModified": 1774654405,
+        "narHash": "sha256-71jT3XLRInSfbXiBgucWwEufe79N3i5FgAAJ1jCiQWg=",
         "owner": "tadfisher",
         "repo": "android-nixpkgs",
-        "rev": "d3cbdd2a82b3d054b4e283d28ba27548186a88e7",
+        "rev": "0afc63ee6baf0914918169427744cc09ee651ebc",
         "type": "github"
       },
       "original": {
         "owner": "tadfisher",
         "repo": "android-nixpkgs",
-        "rev": "d3cbdd2a82b3d054b4e283d28ba27548186a88e7",
+        "rev": "0afc63ee6baf0914918169427744cc09ee651ebc",
         "type": "github"
       }
     },
@@ -198,11 +198,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741473158,
-        "narHash": "sha256-kWNaq6wQUbUMlPgw8Y+9/9wP0F8SHkjy24/mN3UAppg=",
+        "lastModified": 1768818222,
+        "narHash": "sha256-460jc0+CZfyaO8+w8JNtlClB2n4ui1RbHfPTLkpwhU8=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "7c9e793ebe66bcba8292989a68c0419b737a22a0",
+        "rev": "255a2b1725a20d060f566e4755dbf571bbbb5f76",
         "type": "github"
       },
       "original": {
@@ -224,16 +224,16 @@
         "wild": "wild"
       },
       "locked": {
-        "lastModified": 1782316096,
-        "narHash": "sha256-fAkwJ6ixNYqvu9nrcrj9kc5H2XMij9M1Pe3qa/a6row=",
+        "lastModified": 1787842686,
+        "narHash": "sha256-a/z19LZ55fVgIfm4WVeScXKGZSzFpSRNgoD3ctEQcoA=",
         "owner": "fedimint",
         "repo": "fedimint",
-        "rev": "64dc2aa4301dec42fb3f982913aac8aae78c2061",
+        "rev": "2ead392ba22141bbe5898cdb724ec3dbc55387a9",
         "type": "github"
       },
       "original": {
         "owner": "fedimint",
-        "ref": "64dc2aa4301dec42fb3f982913aac8aae78c2061",
+        "ref": "v0.12.0",
         "repo": "fedimint",
         "type": "github"
       }
@@ -457,17 +457,17 @@
         "systems": "systems_7"
       },
       "locked": {
-        "lastModified": 1779594164,
-        "narHash": "sha256-HE2rTCVOKSb3KpQZXfXmV86bMkFu/0U1WJhG40hfQJY=",
-        "owner": "dpc",
+        "lastModified": 1785380176,
+        "narHash": "sha256-38BJhZV6ILSu4Sz3PdZsmYMZDTxvikFJXv2stjfDVw0=",
+        "owner": "rustshop",
         "repo": "flakebox",
-        "rev": "34701639bceb5b12e81e2fff913797c0891c919d",
+        "rev": "b36f6b7cb77652c1d4cb7279d8f47fddf07066ae",
         "type": "github"
       },
       "original": {
-        "owner": "dpc",
+        "owner": "rustshop",
         "repo": "flakebox",
-        "rev": "34701639bceb5b12e81e2fff913797c0891c919d",
+        "rev": "b36f6b7cb77652c1d4cb7279d8f47fddf07066ae",
         "type": "github"
       }
     },
@@ -578,16 +578,16 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1779796641,
-        "narHash": "sha256-ZsIrKmhp4vbBXoXXmR/tBXA/UCsAQiJL9vsgZEduhVY=",
+        "lastModified": 1785133411,
+        "narHash": "sha256-Yjv0WEg39KRYS0rBdTbu6Fc/or/ihAKk13W9sQ6VWd0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "25f538306313eae3927264466c70d7001dcea1df",
+        "rev": "2f5a153c270b70cb0f8c11f46d96d6d3bc39f4e3",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    fedimint.url = "github:fedimint/fedimint?ref=64dc2aa4301dec42fb3f982913aac8aae78c2061";
+    fedimint.url = "github:fedimint/fedimint?ref=v0.12.0";
     flake-utils.url = "github:numtide/flake-utils";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
   };

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -157,10 +157,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -625,18 +625,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
@@ -1086,10 +1086,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.7"
   timing:
     dependency: transitive
     description:
@@ -1299,5 +1299,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.9.0-0 <4.0.0"
+  dart: ">=3.8.0-0 <4.0.0"
   flutter: ">=3.29.0"

--- a/rust/ecashapp/Cargo.lock
+++ b/rust/ecashapp/Cargo.lock
@@ -1789,8 +1789,9 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fedimint-aead"
-version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742#3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f875412c8905403a40e5232aa2fd0589a192448ecbd219d74334f24958666e8f"
 dependencies = [
  "anyhow",
  "argon2",
@@ -1801,8 +1802,9 @@ dependencies = [
 
 [[package]]
 name = "fedimint-api-client"
-version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742#3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5d7803bd05fd8fc72acf681708834b838c0b5f4cc1db6c89758eba27efb0a4e"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1827,8 +1829,9 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bip39"
-version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742#3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24bd9178110a61127a3b748568056090e7f9d2d929da1512a3d9160e1bb71ee3"
 dependencies = [
  "bip39",
  "fedimint-client",
@@ -1839,8 +1842,9 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bitcoind"
-version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742#3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107263626f82d229243964b71bfef0e0e28cb178f208934f6ef46518cbe112a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1854,16 +1858,18 @@ dependencies = [
 
 [[package]]
 name = "fedimint-build"
-version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742#3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b6c7835d5ad730e05123d6a6d9d47fadac0e603242002c9ca67abb2b319b01"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "fedimint-client"
-version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742#3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0346fee4983e229f9b4684c9d49985a403decbb251f1c8022ba5942b6746f1e7"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1895,8 +1901,9 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-module"
-version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742#3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f4b1b3cec95407071afd6be366a9c314d94af2daa1c7944ffabcf0fbab85fd"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -1927,8 +1934,9 @@ dependencies = [
 
 [[package]]
 name = "fedimint-connectors"
-version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742#3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc206895ed9855abba5920fd00587978274615ad8fde74902feebf72249ff99b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1959,8 +1967,9 @@ dependencies = [
 
 [[package]]
 name = "fedimint-core"
-version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742#3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dc4760e3213323094c7c1bc02477f3e121b6e81cdd492761e9ec1e2a95a98ff"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -2023,8 +2032,9 @@ dependencies = [
 
 [[package]]
 name = "fedimint-db-locked"
-version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742#3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7db5bf89bc8fdc94872bb946bc30bb2f8601e2082b941ffd8bd99a2e0b00ab99"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2036,8 +2046,9 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive"
-version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742#3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6839b6535396ff3de8166ff0a3ed96670b7d2b86f4da33c98578b6438a718cf"
 dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
@@ -2047,8 +2058,9 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive-secret"
-version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742#3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0081c3385121b72d5f5ab7d56cf15aef6c184e374d39b242257f0f9b353aba7e"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -2060,8 +2072,9 @@ dependencies = [
 
 [[package]]
 name = "fedimint-eventlog"
-version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742#3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bef69a2c37ca6013a1b3bb1b41f9679716b98e083d52e0e38f40f639be2a4a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2078,8 +2091,9 @@ dependencies = [
 
 [[package]]
 name = "fedimint-fountain"
-version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742#3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e227972769bf608da65b2cb0ef8d1ef34b866cd82fa5c53fe5ba2ea2cce3b63a"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -2090,16 +2104,18 @@ dependencies = [
 
 [[package]]
 name = "fedimint-hkdf"
-version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742#3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb66a6a0704e2c7fc4a72671a14e9268f256fb93b8fc3936f0d63516575ae3d7"
 dependencies = [
  "bitcoin_hashes",
 ]
 
 [[package]]
 name = "fedimint-ln-client"
-version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742#3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c03cceb16de69dad2bd3770ca5800b9568b77b93b9d2a72b72675ea8b4beddb7"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2132,8 +2148,9 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-common"
-version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742#3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e378dd3d263dc58cc144f3ba4ccd84169d007334d575c4f90e5e2c9863b0c2b3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2156,8 +2173,9 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnurl"
-version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742#3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e73c228d09d01b1a39828fb29a74455c02be9815103f31196a1df1fc9e8c1842"
 dependencies = [
  "bech32",
  "lightning-invoice",
@@ -2168,8 +2186,9 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-client"
-version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742#3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ffbc47634924cfb7f7b4057469bd985957e7012296e289f5ef176ee4c6990"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2200,8 +2219,9 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-common"
-version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742#3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed4458cfff4c5f6249f642a326726d22dcbbecac19ead23ebfe85e52e381736d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2221,8 +2241,9 @@ dependencies = [
 
 [[package]]
 name = "fedimint-logging"
-version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742#3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3e841f50b3b042ee7255fb552302b4ab96f93236ae38f699f29909f6416499"
 dependencies = [
  "anyhow",
  "tracing-subscriber",
@@ -2230,8 +2251,9 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-client"
-version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742#3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f45d29a9f2c88c5d49453e77261b76ad365d9f58c6b09deea71640c2b7469c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2252,8 +2274,9 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-common"
-version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742#3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56bd58ecfb86ffe179ced9721dcefe65abe902b56e52c6a71881374ffde8124"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -2267,8 +2290,9 @@ dependencies = [
 
 [[package]]
 name = "fedimint-metrics"
-version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742#3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bce0bdea7eee298480336e971aef32595f9f71f537ca5a1912889b0bf96435c"
 dependencies = [
  "anyhow",
  "axum",
@@ -2280,8 +2304,9 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-client"
-version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742#3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0e4c2e77c7f912c7469e141cf03621684e92fecf67c7636e4b89fc05e2f54a4"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2320,8 +2345,9 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-common"
-version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742#3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd8209347ac0f18058a9f10efe48392156ca031cb232974f03610f3609d1f5"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -2334,8 +2360,9 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mintv2-client"
-version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742#3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4d6143e89ed062a014fd090b3e4df0202a4bd7d70a576631df0d9604dee4ac4"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2372,8 +2399,9 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mintv2-common"
-version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742#3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0f08ee793932841584edcaa65bccae8e38748647900e554a06fb4b29c6eda01"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -2386,8 +2414,9 @@ dependencies = [
 
 [[package]]
 name = "fedimint-rocksdb"
-version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742#3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10fb3d0525b8ad826097ec167fdf5c69ed2bc1d0ad59e278cf5d7f3b166d2330"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2403,8 +2432,9 @@ dependencies = [
 
 [[package]]
 name = "fedimint-tbs"
-version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742#3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf31f65a5e9b1df1b442651644617a8bb134f41397c1bb3b2f0fd2b6ea60f79"
 dependencies = [
  "bls12_381",
  "fedimint-core",
@@ -2440,8 +2470,9 @@ dependencies = [
 
 [[package]]
 name = "fedimint-tpe"
-version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742#3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25045c454604a520c44b195e08dc1d79517beb2277b5230780d7a1ade045c41"
 dependencies = [
  "bitcoin_hashes",
  "bls12_381",
@@ -2455,16 +2486,18 @@ dependencies = [
 
 [[package]]
 name = "fedimint-util-error"
-version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742#3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e92b2dd074ddcb1dbb26b65d4d8d4512ca2abc03b8c2f18cfdd570de5d9bb50d"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "fedimint-wallet-client"
-version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742#3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f2d30dd096857ca21e3e34244673b165a1faad6e1981fcbeb7997db8624227a"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2494,8 +2527,9 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-common"
-version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742#3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3943b360389bdd1c0509575fa3ac30bec27ec649fdd468136c02a51f0887e935"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -2510,8 +2544,9 @@ dependencies = [
 
 [[package]]
 name = "fedimint-walletv2-client"
-version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742#3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2d22527c48b0a2241942818e069f9e54acfa32aec8320f5b7c537615234c74"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2538,8 +2573,9 @@ dependencies = [
 
 [[package]]
 name = "fedimint-walletv2-common"
-version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742#3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a977ccac97a040252b775f64213d24510751f682c6fffecb21c3a1769fd80ed9"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -8261,7 +8297,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/rust/ecashapp/Cargo.toml
+++ b/rust/ecashapp/Cargo.toml
@@ -13,28 +13,28 @@ async-stream = "0.3.6"
 async-trait = "0.1.88"
 bitcoin = { version = "0.32.5", features = ["serde"] }
 bitcoin-payment-instructions = { version = "0.4.0", features = [ "http" ]}
-fedimint-api-client = { git = "https://github.com/fedimint/fedimint", rev = "3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742" }
-fedimint-bip39 = { git = "https://github.com/fedimint/fedimint", rev = "3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742" }
-fedimint-core = { git = "https://github.com/fedimint/fedimint", rev = "3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742" }
-fedimint-fountain = { git = "https://github.com/fedimint/fedimint", rev = "3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742" }
-fedimint-client = { git = "https://github.com/fedimint/fedimint", rev = "3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742" }
-fedimint-eventlog = { git = "https://github.com/fedimint/fedimint", rev = "3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742" }
-fedimint-connectors = { git = "https://github.com/fedimint/fedimint", rev = "3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742" }
-fedimint-derive-secret = { git = "https://github.com/fedimint/fedimint", rev = "3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742" }
-fedimint-rocksdb = { git = "https://github.com/fedimint/fedimint", rev = "3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742" }
-fedimint-ln-client = { git = "https://github.com/fedimint/fedimint", rev = "3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742" }
-fedimint-lnv2-client = { git = "https://github.com/fedimint/fedimint", rev = "3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742" }
-fedimint-lnv2-common = { git = "https://github.com/fedimint/fedimint", rev = "3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742" }
-fedimint-ln-common = { git = "https://github.com/fedimint/fedimint", rev = "3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742" }
-fedimint-meta-client = { git = "https://github.com/fedimint/fedimint", rev = "3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742" }
-fedimint-mint-client = { git = "https://github.com/fedimint/fedimint", rev = "3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742" }
-fedimint-mint-common = { git = "https://github.com/fedimint/fedimint", rev = "3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742" }
-fedimint-mintv2-client = { git = "https://github.com/fedimint/fedimint", rev = "3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742" }
-fedimint-mintv2-common = { git = "https://github.com/fedimint/fedimint", rev = "3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742" }
-fedimint-wallet-client = { git = "https://github.com/fedimint/fedimint", rev = "3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742" }
-fedimint-wallet-common = { git = "https://github.com/fedimint/fedimint", rev = "3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742" }
-fedimint-walletv2-client = { git = "https://github.com/fedimint/fedimint", rev = "3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742" }
-fedimint-walletv2-common = { git = "https://github.com/fedimint/fedimint", rev = "3dfb8f5baeb6dcf6cbd268167aae2a2c78b36742" }
+fedimint-api-client = "0.12.0"
+fedimint-bip39 = "0.12.0"
+fedimint-core = "0.12.0"
+fedimint-fountain = "0.12.0"
+fedimint-client = "0.12.0"
+fedimint-eventlog = "0.12.0"
+fedimint-connectors = "0.12.0"
+fedimint-derive-secret = "0.12.0"
+fedimint-rocksdb = "0.12.0"
+fedimint-ln-client = "0.12.0"
+fedimint-lnv2-client = "0.12.0"
+fedimint-lnv2-common = "0.12.0"
+fedimint-ln-common = "0.12.0"
+fedimint-meta-client = "0.12.0"
+fedimint-mint-client = "0.12.0"
+fedimint-mint-common = "0.12.0"
+fedimint-mintv2-client = "0.12.0"
+fedimint-mintv2-common = "0.12.0"
+fedimint-wallet-client = "0.12.0"
+fedimint-wallet-common = "0.12.0"
+fedimint-walletv2-client = "0.12.0"
+fedimint-walletv2-common = "0.12.0"
 hex = "0.4"
 flutter_rust_bridge = "=2.9.0"
 futures-timer = "3.0.3"

--- a/rust/ecashapp/src/multimint.rs
+++ b/rust/ecashapp/src/multimint.rs
@@ -115,6 +115,10 @@ use crate::{
     FederationConfig, FederationConfigKey, FederationConfigKeyPrefix, SeedPhraseAckKey,
 };
 
+/// One day, which since fedimint v0.12 is also the ceiling: both
+/// `LightningClientModule::receive` and the gateway reject anything above
+/// `MAX_INVOICE_EXPIRY_SECS` (`60 * 60 * 24`). Raising this breaks LNv2
+/// receives.
 const DEFAULT_EXPIRY_TIME_SECS: u32 = 86400;
 const CACHE_UPDATE_INTERVAL_SECS: u64 = 30;
 const PRICE_CACHE_UPDATE_INTERVAL_SECS: u64 = 60 * 5;
@@ -771,9 +775,11 @@ fn recovery_module_for_kind(kind: &ModuleKind) -> Option<RecoveryModule> {
 ///
 /// A federation can run both the v1 and v2 module of a kind, and each recovers
 /// independently. Reporting only one of them would stall the bar partway;
-/// summing gives a single monotonic ratio. Modules that don't implement
-/// recovery report 0/0 and so contribute nothing, which is what leaves the
-/// Lightning bar empty — neither `ln` nor `lnv2` has a recovery routine.
+/// summing gives a single monotonic ratio. Only `mint`, `mintv2` and `wallet`
+/// implement recovery; since fedimint v0.12 the rest are skipped outright
+/// (`RecoveryMode::None`) rather than run through a no-op recovery, so they
+/// never report and contribute nothing — which is what leaves the Lightning
+/// bar empty, neither `ln` nor `lnv2` having a recovery routine.
 fn aggregate_recovery_progress(
     module_progress: &BTreeMap<ModuleInstanceId, (RecoveryModule, RecoveryProgress)>,
     recovery_module: RecoveryModule,


### PR DESCRIPTION
Bumping the fedimint dependencies to `v0.12.0`