### PR TITLE
fix: export Rust FFI symbols from the iOS release binary

### DIFF
--- a/.github/actions/ios-build/action.yml
+++ b/.github/actions/ios-build/action.yml
@@ -337,15 +337,12 @@ runs:
           --export-options-plist "$RUNNER_TEMP/ExportOptions.plist"
         ls -lh build/ios/ipa/
 
-    # The Release configuration links Runner as a plain executable, which exports
-    # nothing by default and therefore also dead-strips the Rust graph, since
-    # nothing in Swift/ObjC/Dart-AOT references it and -force_load only keeps the
-    # archive members loaded, not alive. Debug never shows this: there the product
-    # is Runner.debug.dylib, and a dylib exports every global. That difference
-    # shipped v0.11.0-rc.2 to TestFlight with zero frbgen_* exports, where
-    # RustLib.init()'s first dlsym threw before runApp and the app showed a white
-    # screen with no crash report. CI links the app but never launches it, so
-    # assert on the export trie instead. See ios/Flutter/rust_exported_symbols.txt.
+    # Release links Runner as an executable, which exports nothing by default and
+    # so also dead-strips the Rust graph; Debug's dylib hides this because it
+    # exports every global. That shipped v0.11.0-rc.2 with zero frbgen_* exports,
+    # where RustLib.init()'s first dlsym threw before runApp and the app showed a
+    # white screen with no crash report. CI links the app but never launches it,
+    # so assert on the export trie. See ios/Flutter/rust_exported_symbols.txt.
     - name: Verify Rust FFI symbols are exported
       if: inputs.mode == 'release'
       shell: bash
@@ -375,17 +372,17 @@ runs:
           exit 1
         fi
 
-        # The first symbol RustLib.init() looks up, and part of the flutter_rust_bridge
-        # runtime rather than the generated code, so it needs its own glob.
+        # The first symbol RustLib.init() looks up, and part of the FRB runtime
+        # rather than the generated code, so it needs its own glob.
         if ! grep -q ' _frb_get_rust_content_hash$' <<< "$exports"; then
           echo "::error::_frb_get_rust_content_hash is not exported; RustLib.init() throws at launch."
           exit 1
         fi
 
-        # netdev calls nw_path_is_ultra_constrained unconditionally and Apple only
-        # ships it in the iOS 26 SDK, so rust/ecashapp/src/ios_compat.rs defines it
-        # to keep the reference resolving locally. If it appears as an import, the
-        # shim lost the link and dyld aborts at launch below iOS 26.
+        # netdev calls nw_path_is_ultra_constrained unconditionally and Apple ships
+        # it only in the iOS 26 SDK, so rust/ecashapp/src/ios_compat.rs defines it.
+        # If it appears as an import the shim lost the link and dyld aborts at
+        # launch below iOS 26.
         if nm -u "$BIN" | grep -q nw_path_is_ultra_constrained; then
           echo "::error::nw_path_is_ultra_constrained is an undefined import; the ios_compat.rs shim lost the link and the app will not launch below iOS 26."
           exit 1

--- a/.github/actions/ios-build/action.yml
+++ b/.github/actions/ios-build/action.yml
@@ -337,6 +337,62 @@ runs:
           --export-options-plist "$RUNNER_TEMP/ExportOptions.plist"
         ls -lh build/ios/ipa/
 
+    # The Release configuration links Runner as a plain executable, which exports
+    # nothing by default and therefore also dead-strips the Rust graph, since
+    # nothing in Swift/ObjC/Dart-AOT references it and -force_load only keeps the
+    # archive members loaded, not alive. Debug never shows this: there the product
+    # is Runner.debug.dylib, and a dylib exports every global. That difference
+    # shipped v0.11.0-rc.2 to TestFlight with zero frbgen_* exports, where
+    # RustLib.init()'s first dlsym threw before runApp and the app showed a white
+    # screen with no crash report. CI links the app but never launches it, so
+    # assert on the export trie instead. See ios/Flutter/rust_exported_symbols.txt.
+    - name: Verify Rust FFI symbols are exported
+      if: inputs.mode == 'release'
+      shell: bash
+      run: |
+        if [[ "${{ inputs.with-signing }}" == "true" ]]; then
+          # Check what actually ships: export re-signs and strips the archive.
+          IPA=$(ls build/ios/ipa/*.ipa | head -1)
+          rm -rf "$RUNNER_TEMP/ipa-verify"
+          unzip -q -o "$IPA" -d "$RUNNER_TEMP/ipa-verify"
+          BIN=$(find "$RUNNER_TEMP/ipa-verify/Payload" -maxdepth 2 -type f -name Runner | head -1)
+        else
+          BIN="build/ios/iphoneos/Runner.app/Runner"
+        fi
+
+        if [ -z "$BIN" ] || [ ! -f "$BIN" ]; then
+          echo "::error::No Runner binary found to verify"
+          exit 1
+        fi
+        ls -lh "$BIN"
+
+        exports=$(xcrun dyld_info -exports "$BIN")
+
+        generated=$(grep -c ' _frbgen_ecashapp_' <<< "$exports" || true)
+        echo "frbgen_ecashapp_* exports: $generated"
+        if [ "$generated" -eq 0 ]; then
+          echo "::error::No frbgen_ecashapp_* symbols in the export trie. flutter_rust_bridge resolves these with dlsym via ExternalLibrary.process(), so the app will white-screen at RustLib.init(). Check EXPORTED_SYMBOLS_FILE in ios/Flutter/Release.xcconfig."
+          exit 1
+        fi
+
+        # The first symbol RustLib.init() looks up, and part of the flutter_rust_bridge
+        # runtime rather than the generated code, so it needs its own glob.
+        if ! grep -q ' _frb_get_rust_content_hash$' <<< "$exports"; then
+          echo "::error::_frb_get_rust_content_hash is not exported; RustLib.init() throws at launch."
+          exit 1
+        fi
+
+        # netdev calls nw_path_is_ultra_constrained unconditionally and Apple only
+        # ships it in the iOS 26 SDK, so rust/ecashapp/src/ios_compat.rs defines it
+        # to keep the reference resolving locally. If it appears as an import, the
+        # shim lost the link and dyld aborts at launch below iOS 26.
+        if nm -u "$BIN" | grep -q nw_path_is_ultra_constrained; then
+          echo "::error::nw_path_is_ultra_constrained is an undefined import; the ios_compat.rs shim lost the link and the app will not launch below iOS 26."
+          exit 1
+        fi
+
+        echo "Rust FFI symbols are exported and the netdev shim holds."
+
     - name: Clean up signing material
       if: always()
       shell: bash

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -4,15 +4,13 @@
 
 RUST_PROFILE = release
 
-// Release and Profile link the Runner target into a plain executable, unlike
-// Debug which produces Runner.debug.dylib. An executable exports nothing by
-// default, so without this list the Rust FFI entry points are invisible to the
-// dlsym in ExternalLibrary.process() (lib/main.dart) *and* get dead-stripped,
-// because nothing in Swift/ObjC/Dart-AOT references them. That shipped a
-// TestFlight build whose Runner was 4.7 MB with zero frbgen_* exports and a
-// white screen on launch. Set here rather than in Rust.xcconfig so it never
-// applies to Debug, where restricting exports would hide the debug-dylib
-// trampolines the Runner stub links against.
+// Release and Profile link Runner as a plain executable, unlike Debug's
+// Runner.debug.dylib. An executable exports nothing by default, so without this
+// list the Rust FFI entry points are both invisible to the dlsym in
+// ExternalLibrary.process() (lib/main.dart) and dead-stripped — that shipped a
+// 4.7 MB Runner with zero frbgen_* exports and a white screen. Set here rather
+// than Rust.xcconfig so it never applies to Debug, where restricting exports
+// would hide the debug-dylib trampolines the Runner stub links against.
 EXPORTED_SYMBOLS_FILE = $(SRCROOT)/Flutter/rust_exported_symbols.txt
 
 // Same signing hook as Debug.xcconfig — see the comment there. Without it,

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -4,6 +4,17 @@
 
 RUST_PROFILE = release
 
+// Release and Profile link the Runner target into a plain executable, unlike
+// Debug which produces Runner.debug.dylib. An executable exports nothing by
+// default, so without this list the Rust FFI entry points are invisible to the
+// dlsym in ExternalLibrary.process() (lib/main.dart) *and* get dead-stripped,
+// because nothing in Swift/ObjC/Dart-AOT references them. That shipped a
+// TestFlight build whose Runner was 4.7 MB with zero frbgen_* exports and a
+// white screen on launch. Set here rather than in Rust.xcconfig so it never
+// applies to Debug, where restricting exports would hide the debug-dylib
+// trampolines the Runner stub links against.
+EXPORTED_SYMBOLS_FILE = $(SRCROOT)/Flutter/rust_exported_symbols.txt
+
 // Same signing hook as Debug.xcconfig — see the comment there. Without it,
 // Release and Profile have no DEVELOPMENT_TEAM and cannot sign at all, so
 // `flutter run --release` has never been runnable on a device. CI writes this

--- a/ios/Flutter/rust_exported_symbols.txt
+++ b/ios/Flutter/rust_exported_symbols.txt
@@ -1,0 +1,21 @@
+# Symbols that must stay in the Runner executable's dynamic export trie.
+#
+# lib/main.dart loads Rust with ExternalLibrary.process(), i.e. dlsym against
+# the running process, because libecashapp.a is linked statically rather than
+# opened as a dylib. dlsym can only see symbols in the export trie.
+#
+# In Debug the Runner target's product is Runner.debug.dylib, and a dylib
+# exports every global by default, so this never came up. In Release the product
+# is a plain executable, which exports nothing by default and therefore also
+# dead-strips the whole Rust graph — nothing in Swift/ObjC/Dart-AOT references
+# it, and -force_load only guarantees the archive members are loaded, not kept.
+# Listing them here makes them both exported and dead-strip roots.
+#
+# Keep in sync with the symbols flutter_rust_bridge looks up:
+#   _frbgen_ecashapp_*  the generated wire functions (lib/frb_generated.io.dart)
+#   _frb_*              the runtime helpers the flutter_rust_bridge package
+#                       resolves itself (frb_get_rust_content_hash,
+#                       frb_init_frb_dart_api_dl, frb_pde_ffi_dispatcher_*, ...)
+# _frb_* does not match _frbgen_*, so both globs are required.
+_frb_*
+_frbgen_ecashapp_*

--- a/ios/Flutter/rust_exported_symbols.txt
+++ b/ios/Flutter/rust_exported_symbols.txt
@@ -1,21 +1,15 @@
 # Symbols that must stay in the Runner executable's dynamic export trie.
 #
-# lib/main.dart loads Rust with ExternalLibrary.process(), i.e. dlsym against
-# the running process, because libecashapp.a is linked statically rather than
-# opened as a dylib. dlsym can only see symbols in the export trie.
+# lib/main.dart loads Rust with ExternalLibrary.process() — dlsym against the
+# running process — because libecashapp.a is linked statically, and dlsym only
+# sees the export trie. Debug builds Runner.debug.dylib, which exports every
+# global; Release builds an executable, which exports nothing by default and so
+# also dead-strips the whole Rust graph (-force_load keeps archive members
+# loaded, not alive). Listing them here makes them exported and dead-strip roots.
 #
-# In Debug the Runner target's product is Runner.debug.dylib, and a dylib
-# exports every global by default, so this never came up. In Release the product
-# is a plain executable, which exports nothing by default and therefore also
-# dead-strips the whole Rust graph — nothing in Swift/ObjC/Dart-AOT references
-# it, and -force_load only guarantees the archive members are loaded, not kept.
-# Listing them here makes them both exported and dead-strip roots.
+#   _frbgen_ecashapp_*  generated wire functions (lib/frb_generated.io.dart)
+#   _frb_*              runtime helpers flutter_rust_bridge resolves itself
 #
-# Keep in sync with the symbols flutter_rust_bridge looks up:
-#   _frbgen_ecashapp_*  the generated wire functions (lib/frb_generated.io.dart)
-#   _frb_*              the runtime helpers the flutter_rust_bridge package
-#                       resolves itself (frb_get_rust_content_hash,
-#                       frb_init_frb_dart_api_dl, frb_pde_ffi_dispatcher_*, ...)
 # _frb_* does not match _frbgen_*, so both globs are required.
 _frb_*
 _frbgen_ecashapp_*

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -39,57 +39,36 @@ void main() async {
     FlutterForegroundTask.initCommunicationPort();
   }
 
-  // Best effort and outside the guard below: AppLogger degrades to console-only
-  // when this fails, and losing the log must not stop the app starting.
-  try {
-    await AppLogger.init();
-  } catch (e, stack) {
-    debugPrint("Logger initialization failed: $e\n$stack");
-  }
+  await AppLogger.init();
 
-  // Everything up to runApp runs before the first frame, so an uncaught
-  // exception there leaves the FlutterViewController's white view on screen
-  // with no crash report. Draw the failure instead.
-  try {
-    // Initialize deep link handler early to catch cold start links
-    await DeepLinkHandler().init();
+  // Initialize deep link handler early to catch cold start links
+  await DeepLinkHandler().init();
 
-    // On iOS the Rust code is statically linked into the Runner binary, so
-    // there's no separate dylib to dlopen — load symbols from the current process.
-    if (Platform.isIOS) {
-      await RustLib.init(
-        externalLibrary: ExternalLibrary.process(iKnowHowToUseIt: true),
-      );
-    } else {
-      await RustLib.init();
-    }
-    final packageInfo = await PackageInfo.fromPlatform();
-    AppLogger.instance.info(
-      "Starting ecashapp. Version ${packageInfo.version} Build Number: ${packageInfo.buildNumber}",
+  // On iOS the Rust code is statically linked into the Runner binary, so
+  // there's no separate dylib to dlopen — load symbols from the current process.
+  if (Platform.isIOS) {
+    await RustLib.init(
+      externalLibrary: ExternalLibrary.process(iKnowHowToUseIt: true),
     );
-    final Directory dir;
-    if (Platform.isLinux) {
-      final appName = kDebugMode ? 'ecash-app-dev' : 'ecash-app';
-      final homeDir = Platform.environment['HOME']!;
-      dir = Directory('$homeDir/.local/share/$appName');
-      if (!await dir.exists()) {
-        await dir.create(recursive: true);
-      }
-    } else {
-      dir = await getApplicationDocumentsDirectory();
-    }
-    runApp(ecashapp(dir: dir));
-  } catch (e, stack) {
-    // Render before logging: AppLogger._log writes synchronously and unguarded,
-    // so an unwritable log file would throw here and leave exactly the blank
-    // screen this fallback exists to replace.
-    runApp(StartupFailureApp(error: e, stackTrace: stack));
-    try {
-      AppLogger.instance.error("Startup failed before runApp: $e\n$stack");
-    } catch (_) {
-      debugPrint("Startup failed before runApp: $e\n$stack");
-    }
+  } else {
+    await RustLib.init();
   }
+  final packageInfo = await PackageInfo.fromPlatform();
+  AppLogger.instance.info(
+    "Starting ecashapp. Version ${packageInfo.version} Build Number: ${packageInfo.buildNumber}",
+  );
+  final Directory dir;
+  if (Platform.isLinux) {
+    final appName = kDebugMode ? 'ecash-app-dev' : 'ecash-app';
+    final homeDir = Platform.environment['HOME']!;
+    dir = Directory('$homeDir/.local/share/$appName');
+    if (!await dir.exists()) {
+      await dir.create(recursive: true);
+    }
+  } else {
+    dir = await getApplicationDocumentsDirectory();
+  }
+  runApp(ecashapp(dir: dir));
 }
 
 class ecashapp extends StatelessWidget {
@@ -110,61 +89,6 @@ class ecashapp extends StatelessWidget {
       ],
       supportedLocales: const [Locale('en'), Locale('es')],
       home: Splash(dir: dir),
-    );
-  }
-}
-
-/// Shown when startup throws before `runApp`. Dependency-free — no
-/// localization, Rust or plugins — since anything it touched could be what just
-/// failed. Selectable so the error can be copied out of a TestFlight build.
-class StartupFailureApp extends StatelessWidget {
-  final Object error;
-  final StackTrace stackTrace;
-
-  const StartupFailureApp({
-    super.key,
-    required this.error,
-    required this.stackTrace,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      title: "ecashapp",
-      debugShowCheckedModeBanner: false,
-      theme: cypherpunkNinjaTheme,
-      home: Scaffold(
-        body: SafeArea(
-          child: Padding(
-            padding: const EdgeInsets.all(24),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                const Icon(Icons.error_outline, color: Colors.redAccent),
-                const SizedBox(height: 16),
-                // Intentionally English-only: this screen must not depend on
-                // localization, which may be part of what failed.
-                const Text(
-                  "Ecash App failed to start", // i18n-ignore
-                  style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
-                ),
-                const SizedBox(height: 16),
-                Expanded(
-                  child: SingleChildScrollView(
-                    child: SelectableText(
-                      "$error\n\n$stackTrace",
-                      style: const TextStyle(
-                        fontFamily: 'monospace',
-                        fontSize: 12,
-                      ),
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
-      ),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -39,36 +39,52 @@ void main() async {
     FlutterForegroundTask.initCommunicationPort();
   }
 
-  await AppLogger.init();
-
-  // Initialize deep link handler early to catch cold start links
-  await DeepLinkHandler().init();
-
-  // On iOS the Rust code is statically linked into the Runner binary, so
-  // there's no separate dylib to dlopen — load symbols from the current process.
-  if (Platform.isIOS) {
-    await RustLib.init(
-      externalLibrary: ExternalLibrary.process(iKnowHowToUseIt: true),
-    );
-  } else {
-    await RustLib.init();
+  // Best effort, and deliberately outside the guard below: AppLogger degrades
+  // to console-only when this fails, and losing the log must not be the reason
+  // the app does not start.
+  try {
+    await AppLogger.init();
+  } catch (e, stack) {
+    debugPrint("Logger initialization failed: $e\n$stack");
   }
-  final packageInfo = await PackageInfo.fromPlatform();
-  AppLogger.instance.info(
-    "Starting ecashapp. Version ${packageInfo.version} Build Number: ${packageInfo.buildNumber}",
-  );
-  final Directory dir;
-  if (Platform.isLinux) {
-    final appName = kDebugMode ? 'ecash-app-dev' : 'ecash-app';
-    final homeDir = Platform.environment['HOME']!;
-    dir = Directory('$homeDir/.local/share/$appName');
-    if (!await dir.exists()) {
-      await dir.create(recursive: true);
+
+  // Everything from here to runApp happens before the first frame. An uncaught
+  // exception in it leaves the FlutterViewController's own view on screen — a
+  // blank white screen, with no crash and therefore no crash report. Draw the
+  // failure instead of nothing.
+  try {
+    // Initialize deep link handler early to catch cold start links
+    await DeepLinkHandler().init();
+
+    // On iOS the Rust code is statically linked into the Runner binary, so
+    // there's no separate dylib to dlopen — load symbols from the current process.
+    if (Platform.isIOS) {
+      await RustLib.init(
+        externalLibrary: ExternalLibrary.process(iKnowHowToUseIt: true),
+      );
+    } else {
+      await RustLib.init();
     }
-  } else {
-    dir = await getApplicationDocumentsDirectory();
+    final packageInfo = await PackageInfo.fromPlatform();
+    AppLogger.instance.info(
+      "Starting ecashapp. Version ${packageInfo.version} Build Number: ${packageInfo.buildNumber}",
+    );
+    final Directory dir;
+    if (Platform.isLinux) {
+      final appName = kDebugMode ? 'ecash-app-dev' : 'ecash-app';
+      final homeDir = Platform.environment['HOME']!;
+      dir = Directory('$homeDir/.local/share/$appName');
+      if (!await dir.exists()) {
+        await dir.create(recursive: true);
+      }
+    } else {
+      dir = await getApplicationDocumentsDirectory();
+    }
+    runApp(ecashapp(dir: dir));
+  } catch (e, stack) {
+    AppLogger.instance.error("Startup failed before runApp: $e\n$stack");
+    runApp(StartupFailureApp(error: e, stackTrace: stack));
   }
-  runApp(ecashapp(dir: dir));
 }
 
 class ecashapp extends StatelessWidget {
@@ -89,6 +105,60 @@ class ecashapp extends StatelessWidget {
       ],
       supportedLocales: const [Locale('en'), Locale('es')],
       home: Splash(dir: dir),
+    );
+  }
+}
+
+/// Shown when startup throws before `runApp`. Deliberately dependency-free —
+/// no localization, no Rust, no plugins — because anything it touched could be
+/// the thing that just failed. The error is selectable so it can be copied out
+/// of a TestFlight build, where there is no console.
+class StartupFailureApp extends StatelessWidget {
+  final Object error;
+  final StackTrace stackTrace;
+
+  const StartupFailureApp({
+    super.key,
+    required this.error,
+    required this.stackTrace,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: "ecashapp",
+      debugShowCheckedModeBanner: false,
+      theme: cypherpunkNinjaTheme,
+      home: Scaffold(
+        body: SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Icon(Icons.error_outline, color: Colors.redAccent),
+                const SizedBox(height: 16),
+                const Text(
+                  "Ecash App failed to start",
+                  style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: 16),
+                Expanded(
+                  child: SingleChildScrollView(
+                    child: SelectableText(
+                      "$error\n\n$stackTrace",
+                      style: const TextStyle(
+                        fontFamily: 'monospace',
+                        fontSize: 12,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -39,19 +39,17 @@ void main() async {
     FlutterForegroundTask.initCommunicationPort();
   }
 
-  // Best effort, and deliberately outside the guard below: AppLogger degrades
-  // to console-only when this fails, and losing the log must not be the reason
-  // the app does not start.
+  // Best effort and outside the guard below: AppLogger degrades to console-only
+  // when this fails, and losing the log must not stop the app starting.
   try {
     await AppLogger.init();
   } catch (e, stack) {
     debugPrint("Logger initialization failed: $e\n$stack");
   }
 
-  // Everything from here to runApp happens before the first frame. An uncaught
-  // exception in it leaves the FlutterViewController's own view on screen — a
-  // blank white screen, with no crash and therefore no crash report. Draw the
-  // failure instead of nothing.
+  // Everything up to runApp runs before the first frame, so an uncaught
+  // exception there leaves the FlutterViewController's white view on screen
+  // with no crash report. Draw the failure instead.
   try {
     // Initialize deep link handler early to catch cold start links
     await DeepLinkHandler().init();
@@ -82,8 +80,15 @@ void main() async {
     }
     runApp(ecashapp(dir: dir));
   } catch (e, stack) {
-    AppLogger.instance.error("Startup failed before runApp: $e\n$stack");
+    // Render before logging: AppLogger._log writes synchronously and unguarded,
+    // so an unwritable log file would throw here and leave exactly the blank
+    // screen this fallback exists to replace.
     runApp(StartupFailureApp(error: e, stackTrace: stack));
+    try {
+      AppLogger.instance.error("Startup failed before runApp: $e\n$stack");
+    } catch (_) {
+      debugPrint("Startup failed before runApp: $e\n$stack");
+    }
   }
 }
 
@@ -109,10 +114,9 @@ class ecashapp extends StatelessWidget {
   }
 }
 
-/// Shown when startup throws before `runApp`. Deliberately dependency-free —
-/// no localization, no Rust, no plugins — because anything it touched could be
-/// the thing that just failed. The error is selectable so it can be copied out
-/// of a TestFlight build, where there is no console.
+/// Shown when startup throws before `runApp`. Dependency-free — no
+/// localization, Rust or plugins — since anything it touched could be what just
+/// failed. Selectable so the error can be copied out of a TestFlight build.
 class StartupFailureApp extends StatelessWidget {
   final Object error;
   final StackTrace stackTrace;
@@ -138,8 +142,10 @@ class StartupFailureApp extends StatelessWidget {
               children: [
                 const Icon(Icons.error_outline, color: Colors.redAccent),
                 const SizedBox(height: 16),
+                // Intentionally English-only: this screen must not depend on
+                // localization, which may be part of what failed.
                 const Text(
-                  "Ecash App failed to start",
+                  "Ecash App failed to start", // i18n-ignore
                   style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
                 ),
                 const SizedBox(height: 16),


### PR DESCRIPTION
The `v0.11.0-rc.2` TestFlight build launches to a white screen. It is a link difference between the configuration we test on a device and the one we ship.

`lib/main.dart` reaches Rust through `dlsym` (`ExternalLibrary.process()`), which only sees symbols in the binary's dynamic export trie. Debug builds `Runner.debug.dylib` — a dylib exports every global, and exports are dead-strip roots. Release builds a plain executable, which exports nothing by default and therefore also dead-strips the entire Rust graph, since nothing in Swift/ObjC/Dart-AOT references it. `-force_load` keeps archive members loaded, not alive. So `RustLib.init()` threw on its first lookup, before `runApp()` — no crash, no crash report, just the FlutterViewController's own white view.

Verified against the shipped artifact and a fixed local release link:

| | v0.11.0-rc.2 | this branch |
|---|---|---|
| `Runner` | 4.7 MB | 46 MB |
| exports | 201 (200 rocksdb weak-defs + header) | 75 = 62 `frbgen_ecashapp_*` + 13 `_frb_*` |

The 62 matches the 62 `_lookup<>` sites in `frb_generated.io.dart`.

- `EXPORTED_SYMBOLS_FILE` is set in `Release.xcconfig`, not `Rust.xcconfig`, so it never applies to Debug — restricting exports there would hide the debug-dylib trampolines the `Runner` stub links against. It is scoped to the Runner target's Release and Profile configurations, the two that produce an executable.
- CI now asserts the exports on the shipped `.ipa`, since it links the app but never launches it. The check passes on the fixed binary and fails on the shipped broken one.
- `main()` now renders a startup failure instead of nothing, so the next pre-`runApp` exception is not another blank screen.

One thing to know: `rust/ecashapp/src/ios_compat.rs`'s `nw_path_is_ultra_constrained` shim was passing vacuously — netdev's call site was dead-stripped along with the rest of Rust, so the shipped binary had no import of it. Retaining the graph makes the shim live for the first time. It wins the link (`nm -u` is clean, and CI now gates on that), but only a sub-iOS-26 device exercises it at runtime.

Not verified on a device: `project.pbxproj` pins `org.fedimint.app` at target level and no development profile exists for it, so a Release build cannot be installed locally.