### PR TITLE
fix: export store_dart_post_cobject from the iOS release binary

### DIFF
--- a/.github/actions/ios-build/action.yml
+++ b/.github/actions/ios-build/action.yml
@@ -372,18 +372,26 @@ runs:
             return
           fi
 
+          # Exact, not non-zero: "> 0" would pass on 1 of 62.
           generated=$(grep -c ' _frbgen_ecashapp_' <<< "$exports" || true)
-          echo "$label: $(du -h "$bin" | cut -f1)B, $generated frbgen_ecashapp_* exports"
+          expected=$(grep -ohE 'frbgen_ecashapp_[A-Za-z0-9_]+' lib/frb_generated.io.dart | sort -u | wc -l | tr -d ' ')
+          echo "$label: $(du -h "$bin" | cut -f1)B, $generated/$expected frbgen_ecashapp_* exports"
 
-          if [ "$generated" -eq 0 ]; then
-            echo "::error::$label: no frbgen_ecashapp_* symbols in the export trie. flutter_rust_bridge resolves these with dlsym via ExternalLibrary.process(), so the app will white-screen at RustLib.init(). Check EXPORTED_SYMBOLS_FILE and STRIP_STYLE in ios/Flutter/Release.xcconfig."
-            failed=1
-          # The first symbol RustLib.init() looks up, and part of the FRB runtime
-          # rather than the generated code, so it needs its own glob.
-          elif ! grep -q ' _frb_get_rust_content_hash$' <<< "$exports"; then
-            echo "::error::$label: _frb_get_rust_content_hash is not exported; RustLib.init() throws at launch."
+          if [ "$generated" -ne "$expected" ]; then
+            echo "::error::$label: $generated of $expected frbgen_ecashapp_* symbols in the export trie. flutter_rust_bridge resolves these with dlsym via ExternalLibrary.process(), so the app will white-screen at RustLib.init(). Check EXPORTED_SYMBOLS_FILE and STRIP_STYLE in ios/Flutter/Release.xcconfig."
             failed=1
           fi
+
+          # Resolved by dlsym, so nothing references them and a glob covering
+          # nothing fails silently. Re-check multi_package.dart on an FRB bump.
+          for sym in _frb_get_rust_content_hash _frb_init_frb_dart_api_dl \
+                     _frb_pde_ffi_dispatcher_primary _frb_pde_ffi_dispatcher_sync \
+                     _store_dart_post_cobject; do
+            if ! grep -q " ${sym}\$" <<< "$exports"; then
+              echo "::error::$label: $sym is not exported; RustLib.init() throws at launch and the app shows a blank screen with no crash report."
+              failed=1
+            fi
+          done
 
           # netdev calls nw_path_is_ultra_constrained unconditionally and Apple
           # ships it only in the iOS 26 SDK, so rust/ecashapp/src/ios_compat.rs

--- a/ios/Flutter/rust_exported_symbols.txt
+++ b/ios/Flutter/rust_exported_symbols.txt
@@ -13,3 +13,7 @@
 # _frb_* does not match _frbgen_*, so both globs are required.
 _frb_*
 _frbgen_ecashapp_*
+
+# Resolved by dlsym in RustLib.init(), but defined by allo-isolate, so neither
+# glob above covers it. Re-check multi_package.dart when bumping FRB.
+_store_dart_post_cobject


### PR DESCRIPTION
`v0.11.0-rc.4` shipped with all 62 `frbgen_ecashapp_*` exports, all 13 `_frb_*` helpers and a matching content hash, and still white-screened on TestFlight.

`RustLib.init()` was throwing before `runApp`:

```
Failed to lookup symbol 'store_dart_post_cobject':
  dlsym(RTLD_DEFAULT, store_dart_post_cobject): symbol not found
  #5 _setUpRustToDartCommunication (entrypoint.dart:196)
  #8 RustLib.init (frb_generated.dart:34)
```

flutter_rust_bridge resolves that symbol by `dlsym` as well, but `allo-isolate` defines it and it matches neither glob in `rust_exported_symbols.txt`. Since `EXPORTED_SYMBOLS_FILE` also makes exports the dead-strip roots, omitting it removed the symbol from the binary entirely rather than just hiding it — `nm` finds no trace of it in the shipped `.ipa`.

## Changes

- `ios/Flutter/rust_exported_symbols.txt` — add `_store_dart_post_cobject`. This is the entire fix.
- `.github/actions/ios-build/action.yml` — the gate passed this build. It now compares the frbgen count against the names in `frb_generated.io.dart` rather than testing for non-zero (1 of 62 would have passed), and names each dlsym-only symbol explicitly, since a glob that covers nothing is silent at link time.

## Verification

Built Release and ran it on an iPhone XR (iOS 18.7.10), the sub-iOS-26 device where this reproduces:

```
[INFO] Logger initialized...
[INFO] Starting ecashapp. Version 0.11.0 Build Number: 0.11.0
[INFO] Wallet exists: false
```

It reaches `runApp` and the splash logic runs. The updated gate was run against both binaries: passes on the fixed build, fails on the shipped rc.4 naming `_store_dart_post_cobject`.

Worth noting the Flutter version skew (`.flutter-version` is 3.38.3, local was 3.41.4) and the archive strip were both ruled out as causes — the reproducing build was 3.41.4 and unstripped.

## Follow-ups not in this PR

- Nothing surfaces a pre-`runApp` failure at runtime: `main()` has no guard since the `StartupFailureApp` removal in ca408fa7f, and `platformDispatcher.onError` drops anything that is not a tile cancellation. Diagnosing this needed temporary instrumentation.
- Every gate is static — nothing launches the app. A launch smoke test asserting the "Starting ecashapp" log line would have caught all three of these white screens.